### PR TITLE
Default external locale to dutch

### DIFF
--- a/app/instance-initializers/i18n.js
+++ b/app/instance-initializers/i18n.js
@@ -4,7 +4,7 @@ export function initialize(instance) {
   if (i18n.get('locales').includes(localStorage.getItem('locale'))) {
     i18n.set('locale', localStorage.getItem('locale'));
   } else {
-    i18n.set('locale', calculateLocale());
+    i18n.set('locale', 'nl');
   }
 }
 
@@ -13,8 +13,3 @@ export default {
   after: 'ember-data',
   initialize
 };
-
-function calculateLocale() {
-  const language = navigator.languages[0] || navigator.language || navigator.userLanguage;
-  return language.toLowerCase().includes('en') ? 'en' : 'nl';
-}

--- a/app/instance-initializers/i18n.js
+++ b/app/instance-initializers/i18n.js
@@ -3,8 +3,6 @@ export function initialize(instance) {
   const localStorage = instance.lookup('service:local-storage');
   if (i18n.get('locales').includes(localStorage.getItem('locale'))) {
     i18n.set('locale', localStorage.getItem('locale'));
-  } else {
-    i18n.set('locale', 'nl');
   }
 }
 


### PR DESCRIPTION
### Summary
Because our statistics show that the majority of our users speakes the dutch language, and wants to use the site in dutch, but a large part of those users has a english locale as device default. This means a lot of people have a incorrect locale when visiting the site. Therefore it now defaults to dutch and remembers your choice if changed.