### PR TITLE
Make contactsync more clear

### DIFF
--- a/app/templates/users/webdav.hbs
+++ b/app/templates/users/webdav.hbs
@@ -8,7 +8,8 @@
         <p>
           {{t 'Hier kan je alle informatie vinden voor de contactsynchronisatie.
                 Met de contactsynchronisatie is het mogelijk om alle Alpha leden (die hier toestemming voor hebben gegeven) automatisch in je telefoon/contactenlijst toe te voegen.
-                Hoe je deze gegevens kan synchroniseren verschilt per apparaat. Hoe je dit kan instellen kan je vinden via Informatie -> Contacten Synchroniseren.'}}
+                Hoe je deze gegevens kan synchroniseren verschilt per apparaat.'}}
+          <b>{{t 'Hoe je dit kan instellen kan je vinden via Informatie -> Contacten Synchroniseren.'}}</b>
         </p>
         <hr>
 


### PR DESCRIPTION
It appeared that the contact sync info was not clear. This PR makes the text about where to find bold.