### PR TITLE
Fix the youtube regex

### DIFF
--- a/app/initializers/register-showdown-extensions.js
+++ b/app/initializers/register-showdown-extensions.js
@@ -2,7 +2,7 @@ import showdown from 'showdown';
 
 export function initialize() {
   showdown.extension('youtubeEmbed', () => {
-    const youtubeRegex = /.*(\$\(youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([\w\-]+)\).*/g;
+    const youtubeRegex = /.*(\$\(youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([\w-]+)\).*/g;
     return [{
       type: 'lang',
       regex: youtubeRegex,

--- a/app/initializers/register-showdown-extensions.js
+++ b/app/initializers/register-showdown-extensions.js
@@ -2,7 +2,7 @@ import showdown from 'showdown';
 
 export function initialize() {
   showdown.extension('youtubeEmbed', () => {
-    const youtubeRegex = /.*(\$\(youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([^#&?]*)\).*/g;
+    const youtubeRegex = /.*(\$\(youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([\w\-]+)\).*/g;
     return [{
       type: 'lang',
       regex: youtubeRegex,


### PR DESCRIPTION
### Summary
There where some issues with the youtube regex. I found out the issue was that when a URL was before the youtube this screwed to regex. The Issue was that the regex identified the url as youtube. This PR probably fixed it. 