### PR TITLE
Add npmrc file script to production dockerfile 

### DIFF
--- a/.buildkite/build_npmrc.sh
+++ b/.buildkite/build_npmrc.sh
@@ -3,5 +3,4 @@ echo 'Setting up access for :npm: :package: FontAwesome registry'
 cat << EOF >> /app/.npmrc
 @fortawesome:registry=https://npm.fontawesome.com/
 //npm.fontawesome.com/:_authToken=$FA5_TOKEN
-save-exact=true
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM madnificent/ember:3.0.1 as ember
 MAINTAINER C.S.V. Alpha <ict@csvalpha.nl>
 
+# Install NPM Token
+ARG FA5_TOKEN
+COPY .buildkite/build_npmrc.sh /app/.buildkite/build_npmrc.sh
+RUN /app/.buildkite/build_npmrc.sh
+
 COPY package.json /app/package.json
 COPY yarn.lock /app/yarn.lock
 RUN yarn install --ignore-engines


### PR DESCRIPTION
### Summary
~I'm trying to figure out why CI is not working for branch staging~

The Dockerfile.buildkite was good, but the (production) Dockerfile missed the npmrc script so the FontAwesome5 packages would not load correctly (401 unauthorized)