### PR TITLE
Fix the forum post icons from being huge and off-page

### DIFF
--- a/app/styles/components/forum/forum-post.scss
+++ b/app/styles/components/forum/forum-post.scss
@@ -10,9 +10,4 @@
   background-color: $gray-100;
   padding-right: 30px;
   padding-bottom: 0;
-
-  .forum-post-moderation-icon {
-    padding-right: 10px;
-    padding-left: 10px;
-  }
 }

--- a/app/templates/components/forum/forum-post.hbs
+++ b/app/templates/components/forum/forum-post.hbs
@@ -29,24 +29,28 @@
         {{/if}}
       </p>
 
-      <span>
+      <span class="text-muted pr-1">
         {{#if (can 'destroy forum/posts')}}
-          {{#link-to 'forum.categories.category.threads.thread.posts.destroy' post.id}}
-            {{fa-icon 'trash' class="forum-post-moderation-icon"}}
+          {{#link-to 'forum.categories.category.threads.thread.posts.destroy' post.id class="link-highlight px-2"}}
+            {{fa-icon 'trash'}}
           {{/link-to}}
         {{/if}}
 
         {{#if (can 'edit forum/post' post)}}
-          {{#link-to 'forum.categories.category.threads.thread.posts.edit' post.id}}
-            {{fa-icon 'pencil' class="forum-post-moderation-icon"}}
+          {{#link-to 'forum.categories.category.threads.thread.posts.edit' post.id class="link-highlight px-2"}}
+            {{fa-icon 'pencil'}}
           {{/link-to}}
         {{/if}}
 
         {{#if (can 'quote post of forum/thread' post.thread)}}
-          {{fa-icon 'quote-left' class="link-highlight forum-post-moderation-icon" click=(action "quote")}}
+          <span class=" px-2">
+            {{fa-icon 'quote-left' class="link-highlight" click=(action "quote")}}
+          </span>
         {{/if}}
 
-        {{fa-icon 'code' class="link-highlight forum-post-moderation-icon" click=(action "toggleShowMarkdown")}}
+        <span class=" px-2">
+          {{fa-icon 'code' class="link-highlight" click=(action "toggleShowMarkdown")}}
+        </span>
       </span>
     </div>
   </div>


### PR DESCRIPTION
### Summary
Makes the icon-buttons under the forum posts behave normally again

![image](https://user-images.githubusercontent.com/5594436/57330569-b6b44f00-7116-11e9-91f2-f1f919b900f6.png)
