### PR TITLE
Fix youtube regex

### DIFF
--- a/app/initializers/register-showdown-extensions.js
+++ b/app/initializers/register-showdown-extensions.js
@@ -2,12 +2,13 @@ import showdown from 'showdown';
 
 export function initialize() {
   showdown.extension('youtubeEmbed', () => {
-    const youtubeRegex = /.*(\$\(youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([\w-]+)\).*/g;
+    const youtubeRegex = /.*(youtu\.|youtube\.).*(\$\(v\/|e\/|u\/\w+\/|embed\/|v=)([\w-]+)\).*/g;
     return [{
       type: 'lang',
       regex: youtubeRegex,
       replace(text) {
-        const url = `https://www.youtube.com/embed/${youtubeRegex.exec(text)[2]}`;
+        const url = `https://www.youtube.com/embed/${youtubeRegex.exec(text)[3]}`;
+        youtubeRegex.lastIndex = 0; // Reset index, see https://stackoverflow.com/questions/4724701/regexp-exec-returns-null-sporadically
         return `<div class="js-video widescreen"><iframe src="${url}" frameborder="0" allowfullscreen></iframe></div>`;
       }
     }];

--- a/app/initializers/register-showdown-extensions.js
+++ b/app/initializers/register-showdown-extensions.js
@@ -1,8 +1,9 @@
 import showdown from 'showdown';
 
+export const youtubeRegex = /.*\$\(.*(youtu\.|youtube\.).*(v\/|e\/|u\/\w+\/|embed\/|v=)([\w-]+)\).*/g;
+
 export function initialize() {
   showdown.extension('youtubeEmbed', () => {
-    const youtubeRegex = /.*(youtu\.|youtube\.).*(\$\(v\/|e\/|u\/\w+\/|embed\/|v=)([\w-]+)\).*/g;
     return [{
       type: 'lang',
       regex: youtubeRegex,

--- a/tests/unit/helpers/youtube-regex-test.js
+++ b/tests/unit/helpers/youtube-regex-test.js
@@ -1,0 +1,22 @@
+import { youtubeRegex } from 'alpha-amber/initializers/register-showdown-extensions';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | youtube regex');
+
+const youtubeUrl = '$(https://www.youtube.com/watch?v=Sr0g_A00Vvo)';
+const youtubeID = 'Sr0g_A00Vvo';
+
+const nonYoutubeUrl = '$(https://forms.gle/PQRjWdhdg6fWDxQd9)';
+const linkUrl = '[link](https://www.youtube.com/watch?v=Sr0g_A00Vvo)';
+
+test('youtube is recognized', (assert) => {
+  assert.equal(youtubeRegex.exec(youtubeUrl)[3], youtubeID);
+});
+
+test('non youtube is not recognized', (assert) => {
+  assert.equal(youtubeRegex.exec(nonYoutubeUrl), null);
+});
+
+test('link to youtube is not recognized', (assert) => {
+  assert.equal(youtubeRegex.exec(linkUrl), null);
+});


### PR DESCRIPTION
See issue #39

### Summary
This PR fixes the problem where the youtube regex would match urls that weren't youtube urls by making sure that the url is from the domain youtube(.com) or youtu(.be).
