### PR TITLE
Load more button was not visible

### DIFF
--- a/app/components/quick-post.js
+++ b/app/components/quick-post.js
@@ -116,7 +116,7 @@ export default Component.extend(CanMixin, {
       pageParams.sort = '-created_at';
       this.get('store').query('quickpost-message', pageParams).then(result => {
         this.get('messages').addObjects(result);
-        this.set('totalPages', result.get('meta.total-pages'));
+        this.set('totalPages', result.get('meta.page_count'));
       });
       this.set('page', page);
     },


### PR DESCRIPTION
wrong name for a json attribute was used

### Summary
I noticed a loadMore function in app/components/quick-post.js which I found odd since I hadn't seen any load more button on the webpage recently, so I managed to locate the problem, being the use of the wrong name for a the json attribute, namely "meta.total-pages" instead of the correct name "meta.page_count"

### Other information
