### PR TITLE
hotfix/relationship-loading

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -23,20 +23,20 @@ export default JSONAPISerializer.extend({
   normalizeResponse(store, primaryModelClass, payload) {
     if (Array.isArray(payload.data)) {
       payload.data.forEach(data => {
-        delete data.links;
-
         if (data.relationships) {
           Object.keys(data.relationships).forEach(relationship => {
-            delete data.relationships[relationship].links;
+            if (data.relationships[relationship].data) {
+              delete data.relationships[relationship].links;
+            }
           });
         }
       });
     } else {
-      delete payload.data.links;
-
       if (payload.data.relationships) {
         Object.keys(payload.data.relationships).forEach(relationship => {
-          delete payload.data.relationships[relationship].links;
+          if (payload.data.relationships[relationship].data) {
+            delete payload.data.relationships[relationship].links;
+          }
         });
       }
     }


### PR DESCRIPTION
### Summary
Currently the article-comments are not shown. This was because we are dropping link data (since this can be broken due to namespacing issues). However, the relationships was also not present in the 'data' field. This means that the relationship was gone. By only dropping the linkage data when the data field is present we force Ember to use the data field when present (we can use this when the links are wrong) and use the links as fallback. This way the article comments will work again and the models with wrong links (like poll) wil also work