### PR TITLE
Hotfix activity link

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -29,7 +29,7 @@ export default JSONAPISerializer.extend({
       });
     }
 
-    return this._super(...arguments)
+    return this._super(...arguments);
   },
   permissionNameForRoute(routeName, owner) {
     const parts = routeName.split('.');

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -20,30 +20,17 @@ export default JSONAPISerializer.extend({
 
   // Remove all Links data, since AMBER API's JsonAPI::Resources
   // provides wrong links data for namespaced models
-  normalizeResponse(store, primaryModelClass, payload) {
-    if (Array.isArray(payload.data)) {
-      payload.data.forEach(data => {
-        if (data.relationships) {
-          Object.keys(data.relationships).forEach(relationship => {
-            if (data.relationships[relationship].data) {
-              delete data.relationships[relationship].links;
-            }
-          });
+  normalize(typeHash, hash) {
+    if (hash.relationships) {
+      Object.keys(hash.relationships).forEach(relationship => {
+        if (hash.relationships[relationship].data) {
+          delete hash.relationships[relationship].links;
         }
       });
-    } else {
-      if (payload.data.relationships) {
-        Object.keys(payload.data.relationships).forEach(relationship => {
-          if (payload.data.relationships[relationship].data) {
-            delete payload.data.relationships[relationship].links;
-          }
-        });
-      }
     }
 
-    return this._super(...arguments);
+    return this._super(...arguments)
   },
-
   permissionNameForRoute(routeName, owner) {
     const parts = routeName.split('.');
 


### PR DESCRIPTION
### Summary
The 'closing activity' tool is broken. It loads the data and calls a 'pushPayload'. This is not serialized by `normalizeReponse` but it is by `normalize`, so I changed the logic to that method. 

The 'closing indicator' still shows wrong values sometimes but I cannot find why. At least the link is working again
