### PR TITLE
Remove closing activities for members without create form/responses permission

### DIFF
--- a/app/templates/index/authenticated.hbs
+++ b/app/templates/index/authenticated.hbs
@@ -30,7 +30,9 @@
   </div>
   <div class="col-12 col-md-5">
     {{#if (can 'show activities')}}
-      {{tools/closing-activities}}
+      {{#if (can 'create form/responses')}}
+        {{tools/closing-activities}}
+      {{/if}}
       {{tools/upcoming-activities }}
     {{/if}}
     {{#if (can 'show users')}}


### PR DESCRIPTION
It is not useful for members to see closing activities if they cannot enroll for activities. I removed this tool for people without the create form/responses permission

See #63 
