### PR TITLE
Hide read more button in article-card's big view

### DIFF
--- a/app/templates/components/cards/article-card.hbs
+++ b/app/templates/components/cards/article-card.hbs
@@ -46,9 +46,11 @@
     <div class="card-footer">
       <span itemprop="datePublished" content={{moment-format article.createdAt}}> {{moment-calendar article.createdAt}} </span>
       <span>{{t 'component.cards.articleCard.reactions' count=article.amountOfComments}}</span>
-      {{#link-to 'articles.show' article itemprop='url'}}
-        <span class="float-md-right"> {{t 'tag.button.readMore'}} </span>
-      {{/link-to}}
+      {{#if useMaxHeight}}
+        {{#link-to 'articles.show' article itemprop='url'}}
+          <span class="float-md-right"> {{t 'tag.button.readMore'}} </span>
+        {{/link-to}}
+      {{/if}}
     </div>
   </div>
 </article>


### PR DESCRIPTION
Before, the "Meer lezen" button was visible on the page with all the articles and on an article's page itself. When you clicked the button on the articles page, it routes you to the page of the article and when you clicked the button on the article's page itself, it routes to itself. Thus it's unnecessary to have the read more button visible on the article's page and this PR hides it.