### PR TITLE
Make all menu items first-letter uppercase only

### DIFF
--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -192,7 +192,7 @@ mixin:
     sponsorkliks: Sponsorkliks
     profile: Profile
     settings: Settings
-    mailaliases: Mail Aliases
+    mailaliases: Mail aliases
     collections: Collections
     mailModerations: Mail Moderations
     mandates: Mandates

--- a/translations/nl.yaml
+++ b/translations/nl.yaml
@@ -194,7 +194,7 @@ mixin:
     sponsorkliks: Sponsorkliks
     profile: Profiel
     settings: Instellingen
-    mailaliases: Mail Aliassen
+    mailaliases: Mail aliassen
     collections: Incasso"s
     mailModerations: Mail moderaties
     mandates: Mandaten


### PR DESCRIPTION
### Summary
The capitalization of the menu items was inconsistent. This PR only makes the first letter of each menu item uppercase.
![image](https://user-images.githubusercontent.com/7385023/72794541-74975300-3c3c-11ea-8cb1-b8c405f52b47.png)

