### PR TITLE
Fix i18n issue with lustrum page

### DIFF
--- a/app/components/header-nav.js
+++ b/app/components/header-nav.js
@@ -16,7 +16,7 @@ export default Component.extend(CanMixin, {
     return [
       {
         link: 'lustrum',
-        title: this.i18n.t('mixin.menuItems.lustrum'),
+        title: this.intl.t('mixin.menuItems.lustrum'),
         icon: '',
         canAccess: this.can('show lustrum')
       },


### PR DESCRIPTION
### Summary
Ember would not load because the lustrum page commit was merged without updating i18n to intl. 