### PR TITLE
Set local to default nl

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 export default Route.extend(ApplicationRouteMixin, {
   session: service(),
+  intl: service(),
   actions: {
     refresh() {
       this.refresh();
@@ -14,6 +15,7 @@ export default Route.extend(ApplicationRouteMixin, {
   beforeModel() {
     this._super(...arguments);
     moment.locale('nl');
+    this.intl.setLocale(['nl']);
     return this.session.loadAndSetCurrentUser();
   },
 

--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -89,7 +89,7 @@ module.exports = function(/* environment */) {
      * @type {Boolean}
      * @default "false"
      */
-    errorOnMissingTranslations: false,
+    errorOnMissingTranslations: true,
 
     /**
      * removes empty translations from the build output.


### PR DESCRIPTION
### Summary
Ember Intl defaults to en-us, however we do not have that translation (since we use en). So this PR sets the default to nl which fixes the translations.

I also found a method to let the build fail when locals are missing, I enabled this to prevent missing locals (not really relevant to this bug, but it might be usefull)
