### PR TITLE
Fix activity and poll loading

### DIFF
--- a/app/templates/activities/index.hbs
+++ b/app/templates/activities/index.hbs
@@ -20,7 +20,7 @@
   </div>
 
   {{#each pagedModel as |activity|}}
-    <LinkTo @route="activities.show" @model={{activity}} data-test-activity-item={{true}}>
+    <LinkTo @route="activities.show" @model={{activity.id}} data-test-activity-item={{true}}>
       <div class="row rtable-row">
         <span class="col-12 col-md-8 rtable-item">
           {{#if activity.form}}

--- a/app/templates/components/tools/closing-activities.hbs
+++ b/app/templates/components/tools/closing-activities.hbs
@@ -22,7 +22,7 @@
 
     <ul class="list-group list-group-flush">
       {{#each activities as |activity|}}
-        <LinkTo @route="activities.show" @model={{activity}}>
+        <LinkTo @route="activities.show" @model={{activity.id}}>
           <li class="list-group-item">
             <span class="activity-tool-title "> {{activity.title}} </span> <br>
             <span class="activity-tool-start-time text-muted"> {{form/status-dot activity.form}} {{form-opened-label activity.form}}</span>

--- a/app/templates/components/tools/recent-polls.hbs
+++ b/app/templates/components/tools/recent-polls.hbs
@@ -7,7 +7,7 @@
 
   <ul class="list-group list-group-flush">
     {{#each polls as |poll|}}
-      <LinkTo @route="polls.show" @model={{poll}}>
+      <LinkTo @route="polls.show" @model={{poll.id}}>
         <li class="list-group-item">
           <div class="d-flex justify-content-between">
             <span>

--- a/app/templates/components/tools/upcoming-activities.hbs
+++ b/app/templates/components/tools/upcoming-activities.hbs
@@ -21,7 +21,7 @@
 
   <ul class="list-group list-group-flush">
     {{#each activities as |activity|}}
-      <LinkTo @route="activities.show" @model={{activity}}>
+      <LinkTo @route="activities.show" @model={{activity.id}}>
         <li class="list-group-item">
           <span class="activity-tool-title "> {{activity.title}} </span> <br>
           <span class="activity-tool-start-time text-muted"> {{form/status-dot activity.form}} {{activity.formattedStartDate}} </span>


### PR DESCRIPTION
### Summary
When clicking on an activity or poll on the front page or clicking on an activity in the activities page, it showed a blank page. This PR fixes that.