### PR TITLE
Fix dropzone

### DIFF
--- a/app/controllers/photo-albums/photo-album/edit.js
+++ b/app/controllers/photo-albums/photo-album/edit.js
@@ -4,6 +4,7 @@ import { computed } from '@ember/object';
 
 export default Controller.extend({
   store: service(),
+  fetch: service(),
 
   actions: {
     submit() {
@@ -17,6 +18,6 @@ export default Controller.extend({
     }
   },
   dropzoneHeaders: computed(function() {
-    return { 'Authorization': this.get('fetch.authorizationHeader') };
+    return { 'Authorization': this.fetch.authorizationHeader() };
   })
 });

--- a/app/services/message-bus.js
+++ b/app/services/message-bus.js
@@ -5,7 +5,7 @@ export default Service.extend({
   fetch: service(),
 
   init() {
-    messageBus.headers = { 'Authorization': this.get('fetch.authorizationHeader') };
+    messageBus.headers = { 'Authorization': this.fetch.authorizationHeader() };
     messageBus.baseUrl = '/api/';
     messageBus.start();
     this.set('message-bus', messageBus);

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,7 +23,7 @@ module.exports = function(environment) {
       'script-src': '\'self\' www.google-analytics.com www.googletagmanager.com',
       'font-src': '\'self\' fonts.gstatic.com',
       'connect-src': '\'self\' sentry.io',
-      'img-src': '\'self\' camo.csvalpha.nl www.google-analytics.com img.youtube.com data:',
+      'img-src': '\'self\' camo.csvalpha.nl www.google-analytics.com img.youtube.com',
       'style-src': '\'self\' \'unsafe-inline\' fonts.googleapis.com/',
       'media-src': '\'self\'',
       'object-src': '\'self\'',

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,7 +23,7 @@ module.exports = function(environment) {
       'script-src': '\'self\' www.google-analytics.com www.googletagmanager.com',
       'font-src': '\'self\' fonts.gstatic.com',
       'connect-src': '\'self\' sentry.io',
-      'img-src': '\'self\' camo.csvalpha.nl www.google-analytics.com img.youtube.com',
+      'img-src': '\'self\' camo.csvalpha.nl www.google-analytics.com img.youtube.com data:',
       'style-src': '\'self\' \'unsafe-inline\' fonts.googleapis.com/',
       'media-src': '\'self\'',
       'object-src': '\'self\'',


### PR DESCRIPTION
### Summary
Fixes #150 
Also, there was no preview shown of the uploaded images because it is shown as a base64 encoded data string which was not allowed by cors policy. That is also fixed with this PR. 