### PR TITLE
Remove this.get('property') in favor of this.property

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,9 +38,7 @@ module.exports = {
     'ember-suave/require-access-in-comments': 0,
     'ember/no-jquery': 1,
     'ember/no-mixins': 1,
-    'lines-between-class-members': ['error', 'always', { 'exceptAfterSingleLine': true }],
-    // Temp disable new
-    'ember/no-get': 0
+    'lines-between-class-members': ['error', 'always', { 'exceptAfterSingleLine': true }]
   },
   globals: {
     'moment': true

--- a/app/abilities/activity.js
+++ b/app/abilities/activity.js
@@ -25,12 +25,12 @@ export default Ability.extend({
     return this.session.hasPermission('activity.update') || this.isActivityOwner(this.model);
   }),
   canMailEnrolledMembers: computed('model.form', 'session.currentUser', function() {
-    const form = this.get('model.form');
+    const { form } = this.model;
     return !isNone(form) && form.get('hasResponses') && this.isActivityOwner(this.model);
   }),
   canPrintEnrolledMembers: alias('canMailEnrolledMembers'),
   isActivityOwner(activity) {
-    const currentUser = this.get('session.currentUser');
+    const { currentUser } = this.session;
     return !isNone(currentUser) && activity.isOwner(currentUser);
   }
 });

--- a/app/abilities/article.js
+++ b/app/abilities/article.js
@@ -16,7 +16,7 @@ export default Ability.extend({
     return this.session.hasPermission('article.update');
   }),
   canShowArticleComments: computed('model.publiclyVisible', 'session.currentUser', function() {
-    return this.session.hasPermission('article-comment.read') || this.get('model.publiclyVisible');
+    return this.session.hasPermission('article-comment.read') || this.model.publiclyVisible;
   }),
   canEdit: computed('session.currentUser', 'model', function() {
     return this.session.hasPermission('article.update') || this.isArticleOwner(this.model);
@@ -24,7 +24,7 @@ export default Ability.extend({
   isArticleOwner(article) {
     // This can be reached while not logged in: when a user visits a public article, this method is called to
     // determine whether to show the edit button
-    const currentUser = this.get('session.currentUser');
+    const { currentUser } = this.session;
     return !isNone(currentUser) && article.isOwner(currentUser);
   }
 });

--- a/app/abilities/form/response.js
+++ b/app/abilities/form/response.js
@@ -15,6 +15,6 @@ export default Ability.extend({
     return this.session.hasPermission('form/response.destroy') || this.isResponseOwner(this.model);
   }),
   isResponseOwner(response) {
-    return !isNone(response) && response.get('user.id') === this.get('session.currentUser.id');
+    return !isNone(response) && response.get('user.id') === this.session.currentUser.id;
   }
 });

--- a/app/abilities/forum/post.js
+++ b/app/abilities/forum/post.js
@@ -12,7 +12,7 @@ export default Ability.extend({
     return this.session.hasPermission('forum/post.destroy');
   }),
   canEdit: computed('session.currentUser', 'model.author.id', 'model.thread.closedAt', function() {
-    if (this.isThreadClosed(this.get('model.thread'))) {
+    if (this.isThreadClosed(this.model.thread)) {
       // Permission to both update post and thread
       return this.session.hasPermission('forum/post.update') && this.session.hasPermission('forum/thread.update');
     }
@@ -24,7 +24,7 @@ export default Ability.extend({
     return moment().isAfter(thread.get('closedAt'));
   },
   isPostOwner(post) {
-    const currentUser = this.get('session.currentUser');
+    const { currentUser } = this.session;
     return !isNone(currentUser) && (post.get('author.id') === currentUser.get('id'));
   }
 });

--- a/app/abilities/forum/thread.js
+++ b/app/abilities/forum/thread.js
@@ -18,7 +18,7 @@ export default Ability.extend({
     return this.session.hasPermission('forum/thread.destroy');
   }),
   canCreatePost: computed('session.currentUser', 'model.isOpen', function() {
-    return (this.get('model.isOpen') || this.session.hasPermission('forum/thread.update'))
+    return (this.model.isOpen || this.session.hasPermission('forum/thread.update'))
       && this.session.hasPermission('forum/post.create');
   }),
   canQuotePost: alias('canCreatePost')

--- a/app/abilities/group.js
+++ b/app/abilities/group.js
@@ -22,7 +22,7 @@ export default Ability.extend({
     return this.session.hasPermission('group.update');
   }),
   isGroupMember(group) {
-    const currentUser = this.get('session.currentUser');
+    const { currentUser } = this.session;
     return !isNone(currentUser) && group.get('memberships').filterBy('userIsCurrentlyMember').mapBy('user.id').includes(currentUser.get('id'));
   }
 });

--- a/app/abilities/photo.js
+++ b/app/abilities/photo.js
@@ -8,6 +8,6 @@ export default Ability.extend({
     return this.session.hasPermission('photo.destroy');
   }),
   canShowPhotoComments: computed('model.photoAlbum.publiclyVisible', 'session.currentUser', function() {
-    return this.session.hasPermission('photo-comment.read') || this.get('model.photoAlbum.publiclyVisible');
+    return this.session.hasPermission('photo-comment.read') || this.model.photoAlbum.publiclyVisible;
   })
 });

--- a/app/abilities/poll.js
+++ b/app/abilities/poll.js
@@ -18,7 +18,7 @@ export default Ability.extend({
     return this.session.hasPermission('poll.update') || this.isPollOwner(this.model);
   }),
   isPollOwner(poll) {
-    const currentUser = this.get('session.currentUser');
+    const { currentUser } = this.session;
     return !isNone(currentUser) && poll.isOwner(currentUser);
   }
 });

--- a/app/abilities/user.js
+++ b/app/abilities/user.js
@@ -32,9 +32,9 @@ export default Ability.extend({
     return this.isCurrentUser || this.session.hasPermission('user.update');
   }),
   canResendActivationCode: computed('model.activatedAt', 'session.currentUser', function() {
-    return this.session.hasPermission('user.create') && this.get('model.activatedAt') === null;
+    return this.session.hasPermission('user.create') && this.model.activatedAt === null;
   }),
   isCurrentUser: computed('session.currentUser.id', 'model.id', function() {
-    return this.get('model.id') === this.get('session.currentUser.id');
+    return this.model.id === this.session.currentUser.id;
   })
 });

--- a/app/components/cards/frontpage-activity-card-small.js
+++ b/app/components/cards/frontpage-activity-card-small.js
@@ -5,7 +5,7 @@ import { htmlSafe } from '@ember/string';
 const FrontpageActivityCardSmall = Component.extend({
   classNames: ['card', 'frontpage-activity-card-small', 'border-0', 'p-0'],
   style: computed('activity.coverPhotoUrlOrDefault', function() {
-    return htmlSafe(`background-image: url(${this.get('activity.coverPhotoUrlOrDefault')})`);
+    return htmlSafe(`background-image: url(${this.activity.coverPhotoUrlOrDefault})`);
   })
 });
 

--- a/app/components/flash-notice.js
+++ b/app/components/flash-notice.js
@@ -9,10 +9,10 @@ export default Component.extend({
   flashNoticeContent: null,
   flashNoticeIsPermanent: null,
   flashNoticeVisibilityObserver: observer('flashNotice.visibility', function() {
-    this.set('flashNoticeVisibility', this.get('flashNotice.visibility'));
-    this.set('flashNoticeStatus', this.get('flashNotice.status'));
-    this.set('flashNoticeContent', this.get('flashNotice.content'));
-    this.set('flashNoticeIsPermanent', this.get('flashNotice.isPermanent'));
+    this.set('flashNoticeVisibility', this.flashNotice.visibility);
+    this.set('flashNoticeStatus', this.flashNotice.status);
+    this.set('flashNoticeContent', this.flashNotice.content);
+    this.set('flashNoticeIsPermanent', this.flashNotice.isPermanent);
   }),
   actions: {
     dismissFlashNotice() {
@@ -23,6 +23,6 @@ export default Component.extend({
     this._super();
 
     // Initialize observers
-    this.get('flashNotice.visibility');
+    this.flashNotice.visibility;
   }
 });

--- a/app/components/form/response/closed-question.js
+++ b/app/components/form/response/closed-question.js
@@ -5,7 +5,7 @@ import { computed } from '@ember/object';
 export const ClosedQuestionBaseComponent = Component.extend({
   question: null,
   options: computed('question.sortedOptions.@each.option', function() {
-    return this.get('question.sortedOptions').map(option => {
+    return this.question.sortedOptions.map(option => {
       return {
         label: option.get('option'),
         value: option.id
@@ -13,7 +13,7 @@ export const ClosedQuestionBaseComponent = Component.extend({
     });
   }),
   inputIdentifier: computed('question.id', function() {
-    return `question-${this.get('question.id')}`;
+    return `question-${this.question.id}`;
   })
 });
 
@@ -22,10 +22,10 @@ const ClosedQuestionComponent = ClosedQuestionBaseComponent.extend({
   errors: alias('answer.errors'),
   selectedOptionId: computed('answer.option.id', {
     get() {
-      return this.get('answer.option.id');
+      return this.answer.option.id;
     },
     set(key, value) {
-      const option = this.get('question.options').findBy('id', value);
+      const option = this.question.options.findBy('id', value);
       this.answer.set('option', option);
       return value;
     }

--- a/app/components/form/response/multiple-choice-question.js
+++ b/app/components/form/response/multiple-choice-question.js
@@ -9,7 +9,7 @@ const MultipleChoiceQuestionComponent = ClosedQuestionBaseComponent.extend({
     this.sendAction('updateAnswers', this.question, this.selectedOptionIds);
   }),
   requiredAndNothingSelected: computed('question.required', 'selectedOptionIds.length', function() {
-    return this.get('question.required') && this.get('selectedOptionIds.length') === 0;
+    return this.question.required && this.selectedOptionIds.length === 0;
   })
 });
 

--- a/app/components/form/response/open-question.js
+++ b/app/components/form/response/open-question.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 
 const OpenQuestionComponent = Component.extend({
   inputIdentifier: computed('question.id', function() {
-    return `question-${this.get('question.id')}`;
+    return `question-${this.question.id}`;
   })
 });
 

--- a/app/components/form/response/response-card.js
+++ b/app/components/form/response/response-card.js
@@ -16,7 +16,7 @@ const FormResponseCardComponent = Component.extend({
         this.flashNotice.sendSuccess('Inschrijving opgeslagen');
       }).catch(error => {
         this.set('errorMessage', error.message);
-        if (error.payload.errors && error.payload.errors.isAny('source.pointer', '/data/attributes/user')) {
+        if (error.payload?.errors && error.payload.errors.isAny('source.pointer', '/data/attributes/user')) {
           this.set('errorMessage', 'Er is al een response gevonden, probeer eerst te refreshen, zie je dit formulier dan nog? Neem dan contact op met de ict-commissie.');
         }
       });

--- a/app/components/form/responses-table-totals.js
+++ b/app/components/form/responses-table-totals.js
@@ -1,12 +1,12 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
+import { computed } from '@ember/object';
 
 const ResponsesTableTotalsComponent = Component.extend({
   tagName: 'tr',
   form: null,
   amountOfVegetarians: computed('form.responses', function() {
-    const responses = get(this, 'form.responses');
-    return responses.filterBy('user.vegetarian', true).filterBy('completed', true).length;
+    return this.form.responses.filterBy('user.vegetarian', true)
+      .filterBy('completed', true).length;
   })
 });
 

--- a/app/components/forum/forum-post.js
+++ b/app/components/forum/forum-post.js
@@ -7,9 +7,9 @@ const ForumPostComponent = Component.extend({
       this.toggleProperty('showMarkdown');
     },
     quote() {
-      let header = `${this.get('post.author.fullName')} schreef op ${moment(this.get('post.createdAt')).format('dddd D MMMM gggg @ H:mm')}:`;
+      let header = `${this.post.author.fullName} schreef op ${moment(this.post.createdAt).format('dddd D MMMM gggg @ H:mm')}:`;
       header = `> ___${header}___  \n`;
-      let message = this.get('post.message');
+      let { message } = this.post;
       message = `> ${message}`;
       message = message.split('\n').join('\n> ');
       this.set('newContent', `${this.newContent}${header}${message} \n\n`);

--- a/app/components/header-nav.js
+++ b/app/components/header-nav.js
@@ -42,9 +42,9 @@ export default Component.extend({
   }),
   actions: {
     handleLogoAction() {
-      if (this.get('media.isMobile')) {
+      if (this.media.isMobile) {
         this.send('toggleLeftSidebar');
-      } else if (this.get('routing.currentRouteName') === 'index') {
+      } else if (this.router.currentRouteName === 'index') {
         this.send('refreshItems');
       } else {
         this.router.transitionTo('index');
@@ -63,7 +63,7 @@ export default Component.extend({
       this.layoutManager.closeSidebars();
     },
     toggleLocale() {
-      const locale = this.get('intl.locale');
+      const { locale } = this.intl;
       if (locale[0] === 'nl') {
         this.set('intl.locale', 'en');
         localStorage.setItem('locale', 'en-');

--- a/app/components/lustrum/lustrum-bar.js
+++ b/app/components/lustrum/lustrum-bar.js
@@ -6,7 +6,7 @@ const ActivityCardBar = Component.extend({
   expandable: false,
   expanded: false,
   endsOnSameDateOrNight: computed('activity.startTime', 'activity.endTime', function() {
-    return moment(this.get('activity.endTime')).isSameOrBefore(moment(this.get('activity.startTime')).endOf('day').add(5, 'hours'));
+    return moment(this.activity.endTime).isSameOrBefore(moment(this.activity.startTime).endOf('day').add(5, 'hours'));
   }),
   colorClass: computed('index', function() {
     switch (this.index % 4) {
@@ -21,12 +21,12 @@ const ActivityCardBar = Component.extend({
     return !isNone(this.activity.belongsTo('form').id());
   }),
   canSubmitResponse: computed('activity.form', 'activity.form.currentUserCanRespond', function() {
-    const form = this.get('activity.form');
+    const { form } = this.activity;
     return !isNone(form) && form.get('currentUserCanRespond');
   }),
   excerpt: computed('activity.descriptionCamofied', function() {
     const maxExcerptLength = 218;
-    let content = this.get('activity.descriptionCamofied');
+    let content = this.activity.descriptionCamofied;
     if (content && content.length > maxExcerptLength) {
       return `${content.substr(0, content.lastIndexOf(' ', maxExcerptLength))}...`;
     }

--- a/app/components/model-form/text-input.js
+++ b/app/components/model-form/text-input.js
@@ -24,7 +24,7 @@ export default Component.extend({
   inputIdentifier: computed('model.constructor.modelName', 'property', function() {
     // See http://stackoverflow.com/questions/34864580/ember-data-model-getmodelname-is-undefined-but-model-internalmodel-works
     // On why model.constructor.modelName is used instead of model.modelName
-    return `${this.get('model.constructor.modelName')}-form-${this.property}`;
+    return `${this.model.constructor.modelName}-form-${this.property}`;
   }),
   placeholder: alias('label')
 });

--- a/app/components/privacy-modal.js
+++ b/app/components/privacy-modal.js
@@ -50,7 +50,7 @@ export default Component.extend({
   },
   init() {
     this._super(...arguments);
-    if (this.get('model.userDetailsSharingPreference') === null || this.get('model.allowTomatoSharing') === null) {
+    if (this.model?.userDetailsSharingPreference === null || this.model?.allowTomatoSharing === null) {
       this.set('isOpen', true);
     } else {
       this.set('isOpen', false);

--- a/app/components/quick-post.js
+++ b/app/components/quick-post.js
@@ -76,7 +76,7 @@ export default Component.extend({
       if (message === 'KOE AAN!!') {
         const notificationSound = new Audio('/sounds/cow.ogg');
         this.notification.set('notificationSound', notificationSound);
-        if (this.get('notification.isSoundEnabled')) {
+        if (this.notification.isSoundEnabled) {
           notificationSound.play();
         }
       }
@@ -152,8 +152,8 @@ export default Component.extend({
     },
 
     notify(quickpost) {
-      if (this.get('notification.isEnabled')
-        && quickpost.get('author.id') !== this.get('session.currentUser.id')) {
+      if (this.notification.isEnabled
+        && quickpost.get('author.id') !== this.session.currentUser.id) {
         this.notification.new(
           quickpost.get('author.fullName'),
           quickpost.get('message'),

--- a/app/components/tools/board-room-presence.js
+++ b/app/components/tools/board-room-presence.js
@@ -83,13 +83,11 @@ const BoardRoomPresence = Component.extend({
 
     newPresence() {
       if (this.can.can('create board-room-presences')) {
-        const user = this.get('session.currentUser');
-
         const newPresenceObject = this.store.createRecord('board-room-presence', {
           startTime: moment().startOf('minute').toDate(),
           endTime: moment().startOf('minute').add(1, 'hours').toDate(),
           status: 'present',
-          user
+          user: this.session.currentUser
         });
         this.set('currentUserPresence', newPresenceObject);
       }

--- a/app/components/tools/upcoming-activities.js
+++ b/app/components/tools/upcoming-activities.js
@@ -12,7 +12,7 @@ export default Component.extend({
       sort: 'start_time'
     };
 
-    if (this.get('session.currentUser')) {
+    if (this.session.currentUser) {
       params.page = { size: this.amountOfActivities };
     }
 

--- a/app/components/users/otp-settings.js
+++ b/app/components/users/otp-settings.js
@@ -10,7 +10,7 @@ export default Component.extend({
       this.set('otpErrorMessage', null);
       this.set('otpVerificationImage', null);
 
-      const userId = this.get('model.id');
+      const userId = this.model.id;
       const response = await this.fetch.patch(`/users/${userId}`, {
         /* eslint-disable camelcase */
         body: {
@@ -37,8 +37,7 @@ export default Component.extend({
       this.set('otpErrorMessage', null);
       this.set('otpKey', null);
 
-      const userId = this.get('model.id');
-      const response = await this.fetch.post(`/users/${userId}/generate_otp_secret`);
+      const response = await this.fetch.post(`/users/${this.model.id}/generate_otp_secret`);
       let json = await response.json();
 
       if (response.ok) {
@@ -50,8 +49,7 @@ export default Component.extend({
     async confirmOTP() {
       this.set('otpErrorMessage', null);
 
-      const userId = this.get('model.id');
-      const response = await this.fetch.post(`/users/${userId}/activate_otp`, {
+      const response = await this.fetch.post(`/users/${this.model.id}/activate_otp`, {
         /* eslint-disable camelcase */
         body: {
           one_time_password: this.verificationCode

--- a/app/components/users/password-settings.js
+++ b/app/components/users/password-settings.js
@@ -14,7 +14,7 @@ export default Component.extend({
   actions: {
     async changePassword() {
       this.set('passwordErrorMessage', null);
-      const userId = this.get('model.id');
+      const userId = this.model.id;
       let response = await this.fetch.fetch(`/users/${userId}`, {
         /* eslint-disable camelcase */
         body: JSON.stringify({

--- a/app/components/users/privacy-settings.js
+++ b/app/components/users/privacy-settings.js
@@ -18,10 +18,10 @@ export default Component.extend(ModelSaveMixin, {
     return Object.entries(UserDetailsPreferenceTypes).map(([value, label]) => ({ value, label }));
   }),
   isOwnUser: computed('session.currentUser', 'model', function() {
-    return this.model === this.get('session.currentUser');
+    return this.model === this.session.currentUser;
   }),
   canChangeTomatoSettings: computed('model.allowTomatoSharing', function() {
-    return !isPresent(this.model.changedAttributes().allowTomatoSharing) && this.get('model.allowTomatoSharing');
+    return !isPresent(this.model.changedAttributes().allowTomatoSharing) && this.model.allowTomatoSharing;
   }),
   successMessage: 'Privacyinstellingen gewijzigd!'
 });

--- a/app/controllers/activities/edit.js
+++ b/app/controllers/activities/edit.js
@@ -13,7 +13,7 @@ export default Controller.extend({
   combinedErrors: union('model.errors', 'model.form.errors'),
   activityHasForm: computed('model.form.content', {
     get() {
-      return !isNone(this.get('model.form.content'));
+      return !isNone(this.model.form.content);
     },
     set(_, value) {
       if (value) {
@@ -33,7 +33,7 @@ export default Controller.extend({
       return this.store.findAll('group');
     }
 
-    return this.get('session.currentUser').get('groups');
+    return this.session.currentUser.get('groups');
   }),
 
   _activityCategoryToOption: activityCategory => {

--- a/app/controllers/activities/mail-enrolled.js
+++ b/app/controllers/activities/mail-enrolled.js
@@ -7,10 +7,9 @@ export default Controller.extend({
   errorMessage: null,
   actions: {
     async submit() {
-      const id = this.get('model.id');
       this.set('errorMessage', null);
       if (this.message && this.message.trim().length > 0) {
-        const response = await this.fetch.post(`/activities/${id}/mail_enrolled`, {
+        const response = await this.fetch.post(`/activities/${this.model.id}/mail_enrolled`, {
           body: {
             data: {
               attributes: {
@@ -22,7 +21,7 @@ export default Controller.extend({
 
         if (response.ok) {
           this.set('message', null);
-          this.transitionToRoute('activities.show', this.get('model.id'));
+          this.transitionToRoute('activities.show', this.model.id);
         } else if (isInvalidResponse(response)) {
           const json = await response.json();
           this.set('errorMessage', json.errors ? json.errors[0].detail : response);

--- a/app/controllers/activities/print-enrolled.js
+++ b/app/controllers/activities/print-enrolled.js
@@ -15,7 +15,7 @@ export default Controller.extend({
 
   actions: {
     print() {
-      const title = this.get('model.title');
+      const { title } = this.model;
       const popup = window.open('', 'PRINT', 'height=400,width=600');
 
       popup.document.write(`<html><head><title>Inschrijflijst ${title}</title>`);

--- a/app/controllers/activities/show.js
+++ b/app/controllers/activities/show.js
@@ -6,7 +6,7 @@ import { isNone } from '@ember/utils';
 export default Controller.extend({
   flashNotice: service('flash-notice'),
   canSubmitResponse: computed('model.form', 'model.form.currentUserCanRespond', function() {
-    const form = this.get('model.form');
+    const { form } = this.model;
     return !isNone(form) && form.get('currentUserCanRespond');
   })
 });

--- a/app/controllers/article-comments/destroy.js
+++ b/app/controllers/article-comments/destroy.js
@@ -4,7 +4,7 @@ export default DestroyController.extend({
   successMessage: 'Artikelreactie verwijderd!',
   actions: {
     destroy() {
-      this.set('article', this.get('model.article'));
+      this.set('article', this.model.article);
       this._super(...arguments);
     },
     onSuccess() {

--- a/app/controllers/articles/edit.js
+++ b/app/controllers/articles/edit.js
@@ -6,14 +6,14 @@ export default EditController.extend({
   session: service('session'),
   can: service(),
   successTransitionTarget: 'articles.show',
-  groupOptions: computed('session.currentUser.groups', function() {
+  groupOptions: computed('session.currentUser.{group,groups}', function() {
     const optionArray = [
       {
         label: '',
         value: null
       }
     ];
-    const groups = this.get('session.currentUser.groups');
+    const groups = this.session.currentUser.group;
     groups.forEach((group) => {
       optionArray.push({
         label: group,
@@ -27,7 +27,7 @@ export default EditController.extend({
       return this.store.findAll('group');
     }
 
-    return this.get('session.currentUser').get('groups');
+    return this.session.currentUser.get('groups');
   }),
   actions: {
     coverPhotoLoaded(file) {

--- a/app/controllers/debit/collections/show.js
+++ b/app/controllers/debit/collections/show.js
@@ -5,7 +5,7 @@ export default Controller.extend({
   groupedTransactions: computed('model.transactions.length', 'model.transactions.@each.user', function() {
     const transactions = [];
 
-    this.get('model.transactions').forEach(transaction => {
+    this.model.transactions.forEach(transaction => {
       let transactionsGroupedByUser = transactions.findBy('userId', transaction.get('user.id'));
 
       if (!transactionsGroupedByUser) {

--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -6,14 +6,14 @@ import { run } from '@ember/runloop';
 export default Controller.extend({
   flashNotice: service('flash-notice'),
   showNotFound: computed('model.{isAdapterError,isAuthorizationMixinError}', 'status', function() {
-    return this.get('model.isAuthorizationMixinError')
-      || (this.get('model.isAdapterError') && ['403', '404'].includes(this.status));
+    return this.model.isAuthorizationMixinError
+      || (this.model.isAdapterError && ['403', '404'].includes(this.status));
   }),
   showStatic: computed('status', function() {
     return ['502', '503'].includes(this.status);
   }),
   status: computed('model.errors.firstObject.status', function() {
-    const status = this.get('model.errors.firstObject.status');
+    const { status } = this.model.errors.firstObject;
     return status ? String(status) : status;
   }),
   message: computed('status', function() {

--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -13,7 +13,7 @@ export default Controller.extend({
     return ['502', '503'].includes(this.status);
   }),
   status: computed('model.errors.firstObject.status', function() {
-    const { status } = this.model.errors.firstObject;
+    const status = this.model.errors?.firstObject.status;
     return status ? String(status) : status;
   }),
   message: computed('status', function() {

--- a/app/controllers/form/responses/destroy.js
+++ b/app/controllers/form/responses/destroy.js
@@ -7,13 +7,13 @@ export default DestroyController.extend({
   successTransitionTarget: 'activities.index',
   actions: {
     destroy() {
-      this.set('form', this.get('model.form'));
+      this.set('form', this.model.form);
       this._super(...arguments);
     },
     onSuccess() {
       this._super(...arguments);
       // Reload form to update fields as 'currentUserResponseCompleted', 'currentUserResponseId' and 'amountOfResponses'
-      this.store.peekRecord('form/form', this.get('form.id')).reload();
+      this.store.peekRecord('form/form', this.form.id).reload();
     },
     onError() {
       this.set('errorMessage', 'Er ging iets fout bij het verwijderen');

--- a/app/controllers/forum/categories/category/threads/new.js
+++ b/app/controllers/forum/categories/category/threads/new.js
@@ -11,14 +11,14 @@ export default NewController.extend({
     onSuccess() {
       this._super(...arguments);
       // Reload thread to update thread.amountOfPosts
-      this.get('model.thread').reload();
+      this.model.thread.reload();
       // Reload category to update category.amountOfThreads
-      this.get('model.category').reload();
+      this.model.category.reload();
     },
     submit() {
       this.set('errorMessage', null);
-      const thread = this.get('model.thread');
-      const post = this.get('model.post');
+      const { thread } = this.model;
+      const { post } = this.model;
 
       if (isNone(post.get('message'))) {
         this.set('errorMessage', 'Je moet eerst een bericht aanmaken');

--- a/app/controllers/forum/categories/category/threads/thread/edit.js
+++ b/app/controllers/forum/categories/category/threads/thread/edit.js
@@ -5,7 +5,7 @@ export default EditController.extend({
   successTransitionTarget: 'forum.categories.category.threads.thread',
   actions: {
     submit() {
-      this.send('saveModel', this.get('model.thread'));
+      this.send('saveModel', this.model.thread);
     }
   }
 });

--- a/app/controllers/forum/categories/category/threads/thread/posts/index.js
+++ b/app/controllers/forum/categories/category/threads/thread/posts/index.js
@@ -9,13 +9,11 @@ export default Controller.extend({
   newContent: '',
   queryParams: ['page', 'perPage'],
 
-  count: computed('model.posts', function() {
-    return this.get('model.posts').length;
-  }),
+  count: computed.reads('model.posts.length'),
 
   page: computed('model.posts.page', {
     get() {
-      return this.get('model.posts.page');
+      return this.model.posts.page;
     },
     set(key, value) {
       // The first time this is called, content is null resulting in an error

--- a/app/controllers/groups/index.js
+++ b/app/controllers/groups/index.js
@@ -31,7 +31,7 @@ export default Controller.extend(FilterableAndSortableMixin, {
         return 'zoekresultaten';
       }
 
-      return this.get('groupKinds.firstObject');
+      return this.groupKinds.firstObject;
     },
     set(key, value) {
       return value;

--- a/app/controllers/mail-moderations/accept.js
+++ b/app/controllers/mail-moderations/accept.js
@@ -7,9 +7,8 @@ export default Controller.extend({
   errorMessage: null,
   actions: {
     async submit() {
-      const id = this.get('model.id');
       this.set('errorMessage', null);
-      const response = await this.fetch.post(`/stored_mails/${id}/accept`);
+      const response = await this.fetch.post(`/stored_mails/${this.model.id}/accept`);
 
       if (response.ok) {
         this.model.unloadRecord();

--- a/app/controllers/mail-moderations/reject.js
+++ b/app/controllers/mail-moderations/reject.js
@@ -7,9 +7,8 @@ export default Controller.extend({
   errorMessage: null,
   actions: {
     async submit() {
-      const id = this.get('model.id');
       this.set('errorMessage', null);
-      const response = await this.fetch.post(`/stored_mails/${id}/reject`);
+      const response = await this.fetch.post(`/stored_mails/${this.model.id}/reject`);
 
       if (response.ok) {
         this.model.unloadRecord();

--- a/app/controllers/photo-albums/photo-album/photos/show.js
+++ b/app/controllers/photo-albums/photo-album/photos/show.js
@@ -9,7 +9,7 @@ export default Controller.extend({
   content: null,
   showExif: false,
   advanceToPhoto(delta) {
-    const photos = this.get('model.photoAlbum.photos');
+    const { photos } = this.model.photoAlbum;
     const length = photos.get('length');
     const index = (photos.indexOf(this.model) + delta + length) % length;
     return this.transitionToRoute('photo-albums.photo-album.photos.show', photos.objectAt(index));

--- a/app/controllers/photo-comments/destroy.js
+++ b/app/controllers/photo-comments/destroy.js
@@ -4,7 +4,7 @@ export default DestroyController.extend({
   successMessage: 'Fotoreactie verwijderd!',
   actions: {
     destroy() {
-      this.set('photoAlbum', this.get('model.photo.photoAlbum'));
+      this.set('photoAlbum', this.model.photo.photoAlbum);
       this._super(...arguments);
     },
     onSuccess() {

--- a/app/controllers/polls/show.js
+++ b/app/controllers/polls/show.js
@@ -8,12 +8,12 @@ import formLoadOrCreateMixin from 'alpha-amber/mixins/form-load-or-create-mixin'
 export default Controller.extend(formLoadOrCreateMixin, {
   flashNotice: service('flash-notice'),
   canSubmitResponse: computed('model.form', 'model.form.currentUserCanRespond', function() {
-    const form = this.get('model.form');
+    const { form } = this.model;
     return !isNone(form) && form.get('currentUserCanRespond');
   }),
   optionsWithResults: computed('model.poll.question.options.@each.option', 'model.poll.question.options.@each.sumOfAnswers', 'model.poll.form.amountOfResponses', function() {
-    const options = this.get('model.poll.question.options');
-    const amountOfResponses = this.get('model.poll.form.amountOfResponses');
+    const { options } = this.model.poll.question;
+    const amountOfResponses = this.model.poll.form.get('amountOfResponses');
 
     return options.map(option => {
       // When multiple answers per user are allowed we need to devide by the total amount of users
@@ -33,8 +33,8 @@ export default Controller.extend(formLoadOrCreateMixin, {
   }),
   actions: {
     submitResponse() {
-      const currentUserResponse = this.get('model.currentUserResponse');
-      const form = this.get('model.form');
+      const { currentUserResponse } = this.model;
+      const { form } = this.model;
       currentUserResponse.saveWithAnswers().then(() => {
         // The response is the first thing that is saved (in order to save answers), so currently the response is
         // always 'incomplete'. Furthermore, the form has a field 'amountOfResponses' which should be updated.

--- a/app/controllers/sog/name-trainer.js
+++ b/app/controllers/sog/name-trainer.js
@@ -47,7 +47,7 @@ export default Controller.extend({
   progress: computed('currentQuestionIndex', 'questions.length', function() {
     return this.currentQuestionIndex / this.get('questions.length') * 100;
   }),
-  inputClass: computed('currentQuestion', 'answered', function() {
+  inputClass: computed('answered', 'currentQuestion.success', function() {
     if (this.answered) {
       if (this.currentQuestion.success) {
         return 'form-control is-valid';
@@ -80,7 +80,7 @@ export default Controller.extend({
     },
     chooseOption(option) {
       if (!this.answered) {
-        let currentQuestion = this.currentQuestion;
+        let { currentQuestion } = this;
         currentQuestion.answer = option;
         currentQuestion.success = (option === currentQuestion.question);
         if (currentQuestion.success) {
@@ -91,7 +91,7 @@ export default Controller.extend({
       }
     },
     checkAnswer() {
-      let currentQuestion = this.currentQuestion;
+      let { currentQuestion } = this;
       currentQuestion.answer = this.textInput;
       currentQuestion.success = (currentQuestion.answer === currentQuestion.question.get('fullName'));
       if (currentQuestion.success) {

--- a/app/controllers/sog/name-trainer.js
+++ b/app/controllers/sog/name-trainer.js
@@ -36,20 +36,20 @@ export default Controller.extend({
     return this.store.find('group', this.groupId);
   }),
   humanizedDifficulty: computed('difficulty', 'difficultyOptions', function() {
-    return this.difficultyOptions.find(option => option.value === this.get('difficulty')).label;
+    return this.difficultyOptions.find(option => option.value === this.difficulty).label;
   }),
   progressBarStyle: computed('progress', function() {
     return `width: ${this.progress}%`;
   }),
   currentQuestion: computed('currentQuestionIndex', 'questions', function() {
-    return this.get('questions').objectAt(this.get('currentQuestionIndex') - 1);
+    return this.questions.objectAt(this.currentQuestionIndex - 1);
   }),
   progress: computed('currentQuestionIndex', 'questions.length', function() {
-    return this.get('currentQuestionIndex') / this.get('questions.length') * 100;
+    return this.currentQuestionIndex / this.get('questions.length') * 100;
   }),
   inputClass: computed('currentQuestion', 'answered', function() {
-    if (this.get('answered')) {
-      if (this.get('currentQuestion').success) {
+    if (this.answered) {
+      if (this.currentQuestion.success) {
         return 'form-control is-valid';
       } else {
         return 'form-control is-invalid';
@@ -59,7 +59,7 @@ export default Controller.extend({
     return 'form-control';
   }),
   grade: computed('questions.length', 'success', function() {
-    return 1 + Math.round((90 / this.get('questions.length')) * this.get('success')) / 10;
+    return 1 + Math.round((90 / this.get('questions.length')) * this.success) / 10;
   }),
   actions: {
     setGroupId(model) {
@@ -79,8 +79,8 @@ export default Controller.extend({
       this.set('finished', false);
     },
     chooseOption(option) {
-      if (!this.get('answered')) {
-        let currentQuestion = this.get('currentQuestion');
+      if (!this.answered) {
+        let currentQuestion = this.currentQuestion;
         currentQuestion.answer = option;
         currentQuestion.success = (option === currentQuestion.question);
         if (currentQuestion.success) {
@@ -91,8 +91,8 @@ export default Controller.extend({
       }
     },
     checkAnswer() {
-      let currentQuestion = this.get('currentQuestion');
-      currentQuestion.answer = this.get('textInput');
+      let currentQuestion = this.currentQuestion;
+      currentQuestion.answer = this.textInput;
       currentQuestion.success = (currentQuestion.answer === currentQuestion.question.get('fullName'));
       if (currentQuestion.success) {
         this.incrementProperty('success');

--- a/app/controllers/sog/name-trainer.js
+++ b/app/controllers/sog/name-trainer.js
@@ -26,7 +26,7 @@ export default Controller.extend({
   finished: false,
   answered: false,
   users: computed('group.name', 'store', function() {
-    return this.store.query('user', { filter: { group: this.get('group.name') } });
+    return this.store.query('user', { filter: { group: this.group.name } });
   }),
   group: computed('groupId', 'store', function() {
     if (!this.groupId) {
@@ -45,7 +45,7 @@ export default Controller.extend({
     return this.questions.objectAt(this.currentQuestionIndex - 1);
   }),
   progress: computed('currentQuestionIndex', 'questions.length', function() {
-    return this.currentQuestionIndex / this.get('questions.length') * 100;
+    return this.currentQuestionIndex / this.questions.length * 100;
   }),
   inputClass: computed('answered', 'currentQuestion.success', function() {
     if (this.answered) {
@@ -59,7 +59,7 @@ export default Controller.extend({
     return 'form-control';
   }),
   grade: computed('questions.length', 'success', function() {
-    return 1 + Math.round((90 / this.get('questions.length')) * this.success) / 10;
+    return 1 + Math.round((90 / this.questions.length) * this.success) / 10;
   }),
   actions: {
     setGroupId(model) {

--- a/app/controllers/users/activate-account.js
+++ b/app/controllers/users/activate-account.js
@@ -27,8 +27,7 @@ export default Controller.extend({
 
   actions: {
     async resetPassword() {
-      const userId = this.get('model.id');
-      const response = await this.fetch.post(`/users/${userId}/activate_account`,
+      const response = await this.fetch.post(`/users/${this.model.id}/activate_account`,
         { body: { password: this.password, passwordConfirmation: this.passwordConfirmation, activationToken: this.activation_token } }
       );
 

--- a/app/controllers/users/edit.js
+++ b/app/controllers/users/edit.js
@@ -21,7 +21,7 @@ export default EditController.extend({
     return Object.entries(AlmanakSubscriptionPreferenceTypes).map(([value, label]) => ({ value, label }));
   }),
   isOwnUser: computed('session.currentUser', 'model', function() {
-    return this.model === this.get('session.currentUser');
+    return this.model === this.session.currentUser;
   }),
   actions: {
     fileLoaded(file) {

--- a/app/controllers/users/resend-activation.js
+++ b/app/controllers/users/resend-activation.js
@@ -7,8 +7,7 @@ export default Controller.extend({
   actions: {
     async resendActivation() {
       this.set('errorMessage', null);
-      const userId = this.get('model.id');
-      const response = await this.fetch.post(`/users/${userId}/resend_activation_mail`);
+      const response = await this.fetch.post(`/users/${this.model.id}/resend_activation_mail`);
 
       if (response.ok) {
         this.transitionToRoute('users.show', this.model);

--- a/app/controllers/users/webdav.js
+++ b/app/controllers/users/webdav.js
@@ -6,15 +6,15 @@ export default Controller.extend({
   session: service(),
   fetch: service(),
   webDavEnabled: computed('session.currentUser.webdavSecretKey', function() {
-    return this.get('session.currentUser.webdavSecretKey') !== null;
+    return this.session.currentUser.webdavSecretKey !== null;
   }),
   webDavURL: computed('session.currentUser.webdavSecretKey', 'session.currentUser.id', function() {
-    return `${window.location.origin}/webdav/${this.get('session.currentUser.id')}/${this.get('session.currentUser.webdavSecretKey')}/contacts`;
+    return `${window.location.origin}/webdav/${this.session.currentUser.id}/${this.session.currentUser.webdavSecretKey}/contacts`;
   }),
 
   actions: {
     generateWebdavSecret() {
-      let user = this.get('session.currentUser');
+      let user = this.session.currentUser;
 
       return this.fetch.fetch(`/users/${user.id}/activate_webdav`, { method: 'POST' }).then(function() {
         user.reload();

--- a/app/mixins/check-if-user-is-owner-mixin.js
+++ b/app/mixins/check-if-user-is-owner-mixin.js
@@ -2,12 +2,12 @@ import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({
   isOwner(user) {
-    if (user.id === this.get('author.id')) {
+    if (user.id === this.author.id) {
       return true;
     }
 
     return user.get('memberships').then(() => {
-      return user.get('currentMemberships').some(membership => membership.get('group.id') === this.get('group.id'));
+      return user.get('currentMemberships').some(membership => membership.get('group.id') === this.group.id);
     });
   }
 });

--- a/app/mixins/group-memberships-mixin.js
+++ b/app/mixins/group-memberships-mixin.js
@@ -78,7 +78,7 @@ export default Mixin.create({
   actions: {
     selectFirstItem() {
       if (this.filteredModels.length > 0) {
-        this.transitionToRoute('users.show', this.get('filteredModels.firstObject.user.id'));
+        this.transitionToRoute('users.show', this.filteredModels.firstObject.user.id);
       }
     },
     showOldMemberships() {

--- a/app/mixins/paged-model-controller-mixin.js
+++ b/app/mixins/paged-model-controller-mixin.js
@@ -6,7 +6,7 @@ import { isNone } from '@ember/utils';
 export default Mixin.create({
   page: computed('model.page', {
     get() {
-      return this.get('model.page');
+      return this.model?.page;
     },
     set(key, value) {
       // The first time this is called, content is null resulting in an error

--- a/app/mixins/rollback-model-on-deactivation-route-mixin.js
+++ b/app/mixins/rollback-model-on-deactivation-route-mixin.js
@@ -8,12 +8,9 @@ import Mixin from '@ember/object/mixin';
 export default Mixin.create({
   deactivate() {
     this._super();
-    const model = this.get('controller.model');
-    if (model) {
-      // Calling `rollbackAttributes()` for a saved record reverts all the `changedAttributes` to their original value.
-      // If the record `isNew` it will be removed from the store.
-      // https://guides.emberjs.com/v2.6.0/models/creating-updating-and-deleting-records/#toc_persisting-records
-      model.rollbackAttributes();
-    }
+    // Calling `rollbackAttributes()` for a saved record reverts all the `changedAttributes` to their original value.
+    // If the record `isNew` it will be removed from the store.
+    // https://guides.emberjs.com/v2.6.0/models/creating-updating-and-deleting-records/#toc_persisting-records
+    this.controller.model?.rollbackAttributes();
   }
 });

--- a/app/models/photo-album.js
+++ b/app/models/photo-album.js
@@ -18,9 +18,9 @@ export default Model.extend({
     return adapter.dropzoneEndpoint(this);
   }),
   albumThumbUrl: computed('photos.@each.imageThumbUrl', 'photos.firstObject.imageThumbUrl', function() {
-    return this.get('photos.firstObject.imageThumbUrl') || '/images/fallback/photo_album_thumb_default.png';
+    return this.photos.firstObject.imageThumbUrl || '/images/fallback/photo_album_thumb_default.png';
   }),
   albumMediumUrl: computed('photos.@each.imageMediumUrl', 'photos.firstObject.imageMediumUrl', function() {
-    return this.get('photos.firstObject.imageMediumUrl') || '/images/fallback/photo_album_thumb_default.png';
+    return this.photos.firstObject.imageMediumUrl || '/images/fallback/photo_album_thumb_default.png';
   })
 });

--- a/app/models/poll.js
+++ b/app/models/poll.js
@@ -19,13 +19,13 @@ export default Model.extend(checkIfUserIsOwnerMixin, {
   currentUserCanRespond: alias('form.currentUserCanRespond'),
   currentUserResponseCompleted: alias('form.currentUserResponseCompleted'),
   closesLater: computed('form.respondUntil', function() {
-    return moment().isBefore(this.get('form.respondUntil'));
+    return moment().isBefore(this.form.respondUntil);
   }),
   opensLater: computed('form.respondFrom', function() {
-    return moment().isBefore(this.get('form.respondFrom'));
+    return moment().isBefore(this.form.respondFrom);
   }),
   closedWithNoResponses: computed('form.respondUntil', 'form.amountOfResponses', function() {
-    return moment().isAfter(this.get('form.respondUntil')) && this.get('form.amountOfResponses') === 0;
+    return moment().isAfter(this.form.respondUntil) && this.form.amountOfResponses === 0;
   }),
 
   saveWithForm() {

--- a/app/routes/activities/edit.js
+++ b/app/routes/activities/edit.js
@@ -13,7 +13,6 @@ export default EditRoute.extend({
     return this._super(params).then(activity => activity.get('form').then(() => activity));
   },
   deactivate() {
-    const currentActivity = this.get('controller.model');
-    currentActivity.rollbackAttributesAndForm();
+    this.controller.model.rollbackAttributesAndForm();
   }
 });

--- a/app/routes/activities/new.js
+++ b/app/routes/activities/new.js
@@ -8,7 +8,6 @@ export default NewRoute.extend({
   title: 'Activiteit aanmaken',
   parents: ['activities.index'],
   deactivate() {
-    const currentActivity = this.get('controller.model');
-    currentActivity.rollbackAttributesAndForm();
+    this.controller.model.rollbackAttributesAndForm();
   }
 });

--- a/app/routes/activities/show.js
+++ b/app/routes/activities/show.js
@@ -13,7 +13,7 @@ export default ShowRouteUnauthenticated.extend(formLoadOrCreateMixin, Authentica
   parents: ['activities.index'],
 
   pageActions: computed('can', 'controller.model.activity', function() {
-    const activity = this.get('controller.model.activity');
+    const { activity } = this.controller.model;
     return [
       {
         link: 'activities.edit',
@@ -68,9 +68,6 @@ export default ShowRouteUnauthenticated.extend(formLoadOrCreateMixin, Authentica
   },
 
   deactivate() {
-    const response = this.get('controller.model.currentUserResponse');
-    if (response) {
-      response.rollbackAttributesAndAnswers();
-    }
+    this.controller.model.currentUserResponse?.rollbackAttributesAndAnswers();
   }
 });

--- a/app/routes/articles/new.js
+++ b/app/routes/articles/new.js
@@ -9,7 +9,7 @@ export default NewRoute.extend({
   title: 'Artikel aanmaken',
   model() {
     const newArticle = this.store.createRecord(this.modelName);
-    newArticle.set('author', this.get('session.currentUser'));
+    newArticle.set('author', this.session.currentUser);
     return newArticle;
   }
 });

--- a/app/routes/articles/show.js
+++ b/app/routes/articles/show.js
@@ -9,7 +9,7 @@ export default ShowRouteUnauthenticated.extend({
   title: computed.reads('controller.model.title'),
   parents: ['articles.index'],
   pageActions: computed('can', 'controller.model', function() {
-    const article = this.get('controller.model');
+    const article = this.controller.model;
     return [
       {
         link: 'articles.edit',
@@ -22,7 +22,7 @@ export default ShowRouteUnauthenticated.extend({
         link: 'articles.destroy',
         title: 'Verwijderen',
         icon: 'trash',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('destroy articles')
       }
     ];

--- a/app/routes/debit/collections/show.js
+++ b/app/routes/debit/collections/show.js
@@ -13,7 +13,7 @@ export default ShowRouteUnauthenticated.extend(AuthenticatedRouteMixin, {
   title: alias('controller.model.collection.name'),
   parents: ['debit.collection.index'],
   pageActions: computed('can', 'controller.model.collection', function() {
-    const collection = this.get('controller.model.collection');
+    const { collection } = this.controller.model;
     return [
       {
         link: 'debit.collections.edit',

--- a/app/routes/debit/mandates/show.js
+++ b/app/routes/debit/mandates/show.js
@@ -16,7 +16,7 @@ export default ShowRouteUnauthenticated.extend(AuthenticatedRouteMixin, {
         link: 'debit.mandates.edit',
         title: 'Wijzigen',
         icon: 'pencil-alt',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('edit debit/mandates')
       }
     ];

--- a/app/routes/forum/categories/category/threads/index.js
+++ b/app/routes/forum/categories/category/threads/index.js
@@ -17,14 +17,14 @@ export default IndexRoute.extend({
         link: 'forum.categories.category.edit',
         title: 'Wijzigen',
         icon: 'pencil-alt',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('edit forum/categories')
       },
       {
         link: 'forum.categories.category.destroy',
         title: 'Verwijderen',
         icon: 'trash',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('destroy forum/categories')
       },
       {
@@ -34,7 +34,7 @@ export default IndexRoute.extend({
         // Only pass id when force reload is required, see http://emberigniter.com/force-store-reload-data-api-backend/
         // pass id to force Ember to call model() on forum.categories.threads.new
         // and not use the supplied category model as model for that route (as per Ember's default)
-        linkArgument: this.get('controller.model.id'),
+        linkArgument: this.controller.model.id,
         canAccess: this.can.can('create forum/threads')
       }
     ];

--- a/app/routes/forum/categories/category/threads/new.js
+++ b/app/routes/forum/categories/category/threads/new.js
@@ -14,14 +14,7 @@ export default NewRoute.extend({
     return { category, thread, post };
   },
   deactivate() {
-    const thread = this.get('controller.model.thread');
-    const post = this.get('controller.model.post');
-    if (thread) {
-      thread.rollbackAttributes();
-    }
-
-    if (post) {
-      post.rollbackAttributes();
-    }
+    this.controller.model.thread?.rollbackAttributes();
+    this.controller.model.post?.rollbackAttributes();
   }
 });

--- a/app/routes/forum/categories/category/threads/thread/edit.js
+++ b/app/routes/forum/categories/category/threads/thread/edit.js
@@ -11,9 +11,6 @@ export default EditRoute.extend({
   modelName: 'forum/thread',
   title: 'Topic aanpassen',
   deactivate() {
-    const thread = this.get('controller.model.thread');
-    if (thread) {
-      thread.rollbackAttributes();
-    }
+    this.controller.model.thread?.rollbackAttributes();
   }
 });

--- a/app/routes/forum/categories/category/threads/thread/posts/index.js
+++ b/app/routes/forum/categories/category/threads/thread/posts/index.js
@@ -37,14 +37,14 @@ export default IndexRoute.extend(PagedModelRouteMixin, {
         link: 'forum.categories.category.threads.thread.edit',
         title: 'Wijzigen',
         icon: 'pencil-alt',
-        linkArgument: this.get('controller.model.thread'),
+        linkArgument: this.controller.model.thread,
         canAccess: this.can.can('edit forum/threads')
       },
       {
         link: 'forum.categories.category.threads.thread.destroy',
         title: 'Verwijderen',
         icon: 'trash',
-        linkArgument: this.get('controller.model.thread'),
+        linkArgument: this.controller.model.thread,
         canAccess: this.can.can('destroy forum/threads')
       }
     ];
@@ -57,7 +57,7 @@ export default IndexRoute.extend(PagedModelRouteMixin, {
       // Update forumLastRead
       let currentStore = this.storage.getItem('forumLastRead') || '{}';
       currentStore = JSON.parse(currentStore);
-      currentStore[this.get('controller.model.thread.id')] = new Date();
+      currentStore[this.controller.model.thread.id] = new Date();
       this.storage.setItem('forumLastRead', JSON.stringify(currentStore));
     });
   }

--- a/app/routes/groups/edit.js
+++ b/app/routes/groups/edit.js
@@ -9,7 +9,7 @@ export default EditRoute.extend({
   title: 'Groep aanpassen',
   parents: ['groups.index'],
   deactivate() {
-    const group = this.get('controller.model');
+    const group = this.controller.model;
     group.rollbackAttributesAndMemberships();
   }
 });

--- a/app/routes/groups/new.js
+++ b/app/routes/groups/new.js
@@ -8,7 +8,7 @@ export default NewRoute.extend({
   title: 'Groep aanmaken',
   parents: ['groups.index'],
   deactivate() {
-    const group = this.get('controller.model');
+    const group = this.controller.model;
     group.rollbackAttributesAndMemberships();
   }
 });

--- a/app/routes/groups/show.js
+++ b/app/routes/groups/show.js
@@ -19,7 +19,7 @@ export default ShowRouteUnauthenticated.extend(AuthenticatedRouteMixin, {
   title: computed.reads('controller.model.name'),
   parents: ['groups.index'],
   pageActions: computed('can', 'controller.model', function() {
-    const group = this.get('controller.model');
+    const group = this.controller.model;
     return [
       {
         link: 'groups.edit',

--- a/app/routes/mail-aliases/show.js
+++ b/app/routes/mail-aliases/show.js
@@ -10,7 +10,7 @@ export default ShowRouteUnauthenticated.extend(AuthenticatedRouteMixin, {
   title: computed.reads('controller.model.email'),
   parents: ['mail-aliases.index'],
   pageActions: computed('can', 'controller.model', function() {
-    const mailAlias = this.get('controller.model');
+    const mailAlias = this.controller.model;
     return [
       {
         link: 'mail-aliases.edit',

--- a/app/routes/mail-moderations/show.js
+++ b/app/routes/mail-moderations/show.js
@@ -15,21 +15,21 @@ export default ShowRouteUnauthenticated.extend(AuthenticatedRouteMixin, {
         link: 'mail-moderations.accept',
         title: 'Goedkeuren',
         icon: 'check',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('accept mail-moderations')
       },
       {
         link: 'mail-moderations.reject',
         title: 'Afkeuren',
         icon: 'minus-circle',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('reject mail-moderations')
       },
       {
         link: 'mail-moderations.destroy',
         title: 'Negeren',
         icon: 'trash',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('destroy mail-moderations')
       }
     ];

--- a/app/routes/photo-albums/photo-album/photos/index.js
+++ b/app/routes/photo-albums/photo-album/photos/index.js
@@ -19,14 +19,14 @@ export default IndexRouteUnauthenticated.extend({
         link: 'photo-albums.photo-album.edit',
         title: 'Wijzigen',
         icon: 'pencil-alt',
-        linkArgument: this.get('controller.model.photoAlbum'),
+        linkArgument: this.controller.model.photoAlbum,
         canAccess: this.can.can('edit photo-albums')
       },
       {
         link: 'photo-albums.photo-album.destroy',
         title: 'Verwijderen',
         icon: 'trash',
-        linkArgument: this.get('controller.model.photoAlbum'),
+        linkArgument: this.controller.model.photoAlbum,
         canAccess: this.can.can('destroy photo-albums')
       }
     ];

--- a/app/routes/photo-albums/photo-album/photos/show.js
+++ b/app/routes/photo-albums/photo-album/photos/show.js
@@ -23,8 +23,8 @@ export default ShowRouteUnauthenticated.extend({
   modelRouteParam: 'photo_id',
 
   title: computed('controller.model.id', 'controller.model.photoAlbum.photos', 'controller.model.photos.[]', function() {
-    const photo = this.get('controller.model');
-    const allAlbumPhotos = this.get('controller.model.photoAlbum.photos');
+    const photo = this.controller.model;
+    const allAlbumPhotos = this.controller.model.photoAlbum.photos;
     const photoAlbumPhotosLength = allAlbumPhotos.get('length');
     const currentPhotoIndex = allAlbumPhotos.indexOf(photo) + 1;
 
@@ -35,7 +35,7 @@ export default ShowRouteUnauthenticated.extend({
     return [
       {
         link: 'photo-albums.photo-album.photos.destroy',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         title: 'Foto verwijderen',
         icon: 'trash',
         canAccess: this.can.can('destroy photos')

--- a/app/routes/polls/new.js
+++ b/app/routes/polls/new.js
@@ -9,7 +9,7 @@ export default NewRoute.extend({
   title: 'Poll aanmaken',
   model() {
     const newPoll = this.store.createRecord(this.modelName);
-    newPoll.set('author', this.get('session.currentUser'));
+    newPoll.set('author', this.session.currentUser);
     const newForm = this.store.createRecord('form/form');
     const newQuestion = this.store.createRecord('form/closed-question');
     newQuestion.set('form', newForm);
@@ -20,7 +20,7 @@ export default NewRoute.extend({
     return newPoll;
   },
   deactivate() {
-    const currentPoll = this.get('controller.model');
+    const currentPoll = this.controller.model;
     currentPoll.rollbackAttributesAndForm();
   }
 });

--- a/app/routes/polls/show.js
+++ b/app/routes/polls/show.js
@@ -13,7 +13,7 @@ export default ShowRouteUnauthenticated.extend(formLoadOrCreateMixin, Authentica
   title: computed.reads('controller.model.poll.question.question'),
   parents: ['poll.index'],
   pageActions: computed('can', 'controller.model.poll', function() {
-    const poll = this.get('controller.model.poll');
+    const { poll } = this.controller.model;
     return [
       {
         link: 'polls.edit',

--- a/app/routes/static-pages/show.js
+++ b/app/routes/static-pages/show.js
@@ -14,14 +14,14 @@ export default ShowRouteUnauthenticated.extend({
         link: 'static-pages.edit',
         title: 'Wijzigen',
         icon: 'pencil-alt',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('edit static-pages')
       },
       {
         link: 'static-pages.destroy',
         title: 'Verwijderen',
         icon: 'trash',
-        linkArgument: this.get('controller.model'),
+        linkArgument: this.controller.model,
         canAccess: this.can.can('destroy static-pages')
       }
     ];

--- a/app/routes/users/edit.js
+++ b/app/routes/users/edit.js
@@ -10,7 +10,7 @@ export default EditRoute.extend({
   title: 'Lid aanpassen',
   parents: ['users.index'],
   tabItems: computed('can', 'controller.model', 'session.currentUser', function() {
-    const user = this.get('controller.model');
+    const user = this.controller.model;
     return [
       {
         link: 'users.edit',
@@ -28,13 +28,13 @@ export default EditRoute.extend({
         link: 'users.edit-privacy',
         title: 'Privacy',
         linkArgument: user,
-        canAccess: this.get('session.currentUser') === user
+        canAccess: this.session.currentUser === user
       },
       {
         link: 'users.edit-security',
         title: 'Beveiliging',
         linkArgument: user,
-        canAccess: this.get('session.currentUser') === user
+        canAccess: this.session.currentUser === user
       }
     ];
   })

--- a/app/routes/users/resend-activation.js
+++ b/app/routes/users/resend-activation.js
@@ -9,6 +9,6 @@ export default ShowRouteUnauthenticated.extend(AuthenticatedRouteMixin, {
   },
   modelName: 'user',
   title: computed('controller.model.fullName', function() {
-    return `Activatiecode hersturen van ${this.get('controller.model.fullName')}`;
+    return `Activatiecode hersturen van ${this.controller.model.fullName}`;
   })
 });

--- a/app/routes/users/show-permissions.js
+++ b/app/routes/users/show-permissions.js
@@ -6,7 +6,7 @@ export default UserShowRouteUnauthenticated.extend({
     return this.can.can('show permissions-users');
   },
   pageActions: computed('can', 'controller.model', function() {
-    const user = this.get('controller.model');
+    const user = this.controller.model;
     return [
       {
         link: 'users.edit-permissions',

--- a/app/routes/users/show-settings.js
+++ b/app/routes/users/show-settings.js
@@ -7,7 +7,7 @@ export default UserShowRouteUnauthenticated.extend({
     return this.checkAccessWithPromise(this.can.can('edit user', user), transition);
   },
   pageActions: computed('can', 'controller.model', function() {
-    const user = this.get('controller.model');
+    const user = this.controller.model;
     return [
       {
         link: 'users.edit-privacy',

--- a/app/routes/users/show.js
+++ b/app/routes/users/show.js
@@ -10,7 +10,7 @@ const UserShowRouteUnauthenticated = ShowRouteUnauthenticated.extend(Authenticat
   title: computed.reads('controller.model.fullName'),
   parents: ['users.index'],
   pageActions: computed('can', 'controller.model', function() {
-    const user = this.get('controller.model');
+    const user = this.controller.model;
     return [
       {
         link: 'users.edit',
@@ -24,7 +24,7 @@ const UserShowRouteUnauthenticated = ShowRouteUnauthenticated.extend(Authenticat
         title: 'Verwijderen',
         icon: 'trash',
         linkArgument: user,
-        canAccess: this.can.can('destroy users')
+        canAccess: this.can.can('destroy user', user)
       },
       {
         link: 'users.resend_activation',
@@ -36,7 +36,7 @@ const UserShowRouteUnauthenticated = ShowRouteUnauthenticated.extend(Authenticat
     ];
   }),
   tabItems: computed('can', 'controller.model', function() {
-    const user = this.get('controller.model');
+    const user = this.controller.model;
     return [
       {
         link: 'users.show',

--- a/app/services/fetch.js
+++ b/app/services/fetch.js
@@ -48,7 +48,7 @@ export default Service.extend({
   },
 
   authorizationHeader() {
-    const accessToken = this.get('session.data.authenticated.access_token');
+    const accessToken = this.session.data.authenticated.access_token;
     if (accessToken) {
       return `Bearer ${accessToken}`;
     }

--- a/app/services/layout-manager.js
+++ b/app/services/layout-manager.js
@@ -7,7 +7,7 @@ export default Service.extend({
   localStorage: inject(),
   leftSideBarOpen: computed('media.isMobile', 'session.isAuthenticated', {
     get() {
-      return (!this.get('media.isMobile') && this.get('session.isAuthenticated'));
+      return (!this.media.isMobile && this.session.isAuthenticated);
     },
     set(key, value) {
       return value;
@@ -15,7 +15,7 @@ export default Service.extend({
   }),
   leftSideBarExpanded: computed('media.isMobile', 'localStorage', {
     get() {
-      if (this.get('media.isMobile')) {
+      if (this.media.isMobile) {
         return true;
       }
 
@@ -59,7 +59,7 @@ export default Service.extend({
     this.set('leftSideBarExpanded', false);
   },
   closeLeftSidebarIfOnMobile() {
-    if (this.get('media.isMobile')) {
+    if (this.media.isMobile) {
       this.closeLeftSidebar();
     }
   }

--- a/tests/unit/controllers/groups/edit-test.js
+++ b/tests/unit/controllers/groups/edit-test.js
@@ -6,9 +6,9 @@ module('Unit | Controller | groups/edit', function(hooks) {
 
   test('test if groupKindOptions contains options with capitalized labels', function(assert) {
     const controller = this.owner.lookup('controller:groups/edit')
-    assert.equal('Bestuur', controller.get('groupKindOptions').findBy('value', 'bestuur').label);
-    assert.equal('Commissie', controller.get('groupKindOptions').findBy('value', 'commissie').label);
-    assert.equal('Huis', controller.get('groupKindOptions').findBy('value', 'huis').label);
+    assert.equal('Bestuur', controller.groupKindOptions.findBy('value', 'bestuur').label);
+    assert.equal('Commissie', controller.groupKindOptions.findBy('value', 'commissie').label);
+    assert.equal('Huis', controller.groupKindOptions.findBy('value', 'huis').label);
   });
 });
 

--- a/tests/unit/routes/articles/edit-test.js
+++ b/tests/unit/routes/articles/edit-test.js
@@ -7,6 +7,6 @@ module('Unit | Route | articles/edit', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:articles/edit');
 
-    assert.equal('article', route.get('modelName'));
+    assert.equal('article', route.modelName);
   });
 });

--- a/tests/unit/routes/articles/index-test.js
+++ b/tests/unit/routes/articles/index-test.js
@@ -7,6 +7,6 @@ module('Unit | Route | articles/index', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:articles/index');
 
-    assert.equal('article', route.get('modelName'));
+    assert.equal('article', route.modelName);
   });
 });

--- a/tests/unit/routes/articles/new-test.js
+++ b/tests/unit/routes/articles/new-test.js
@@ -7,6 +7,6 @@ module('Unit | Route | articles/new', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:articles/new');
 
-    assert.equal('article', route.get('modelName'));
+    assert.equal('article', route.modelName);
   });
 });

--- a/tests/unit/routes/articles/show-test.js
+++ b/tests/unit/routes/articles/show-test.js
@@ -7,6 +7,6 @@ module('Unit | Route | articles/show', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:articles/show');
 
-    assert.equal('article', route.get('modelName'));
+    assert.equal('article', route.modelName);
   });
 });

--- a/tests/unit/routes/groups/edit-test.js
+++ b/tests/unit/routes/groups/edit-test.js
@@ -24,6 +24,6 @@ module('Unit | Route | groups/edit', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:groups/edit');
 
-    assert.equal('group', route.get('modelName'));
+    assert.equal('group', route.modelName);
   });
 });

--- a/tests/unit/routes/polls/destroy-test.js
+++ b/tests/unit/routes/polls/destroy-test.js
@@ -12,6 +12,6 @@ module('Unit | Route | polls/destroy', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:polls/destroy');
 
-    assert.equal('poll', route.get('modelName'));
+    assert.equal('poll', route.modelName);
   });
 });

--- a/tests/unit/routes/polls/edit-test.js
+++ b/tests/unit/routes/polls/edit-test.js
@@ -12,6 +12,6 @@ module('Unit | Route | polls/edit', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:polls/edit');
 
-    assert.equal('poll', route.get('modelName'));
+    assert.equal('poll', route.modelName);
   });
 });

--- a/tests/unit/routes/polls/index-test.js
+++ b/tests/unit/routes/polls/index-test.js
@@ -12,6 +12,6 @@ module('Unit | Route | polls/index', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:polls/index');
 
-    assert.equal('poll', route.get('modelName'));
+    assert.equal('poll', route.modelName);
   });
 });

--- a/tests/unit/routes/polls/new-test.js
+++ b/tests/unit/routes/polls/new-test.js
@@ -12,6 +12,6 @@ module('Unit | Route | polls/new', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:polls/new');
 
-    assert.equal('poll', route.get('modelName'));
+    assert.equal('poll', route.modelName);
   });
 });

--- a/tests/unit/routes/polls/show-test.js
+++ b/tests/unit/routes/polls/show-test.js
@@ -12,6 +12,6 @@ module('Unit | Route | polls/show', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:polls/show');
 
-    assert.equal('poll', route.get('modelName'));
+    assert.equal('poll', route.modelName);
   });
 });

--- a/tests/unit/routes/users/edit-test.js
+++ b/tests/unit/routes/users/edit-test.js
@@ -24,6 +24,6 @@ module('Unit | Route | users/edit', function(hooks) {
   test('it has a correct modelName', function(assert) {
     const route = this.owner.lookup('route:users/edit');
 
-    assert.equal('user', route.get('modelName'));
+    assert.equal('user', route.modelName);
   });
 });


### PR DESCRIPTION
### Summary
For most calls we don't need `this.get('')` anymore, we simply do `this.property`. This PR removes all the cases. The only issue is that `this.property.something` could fail when property is undefined. However, that is actually quite handy since I already found some bugs that did not raise an error due to the `.get()`. Hopefully there are no bugs but could be that this introduces some.
