### PR TITLE
Fix article and activity always showing edit button

### DIFF
--- a/app/mixins/check-if-user-is-owner-mixin.js
+++ b/app/mixins/check-if-user-is-owner-mixin.js
@@ -6,8 +6,6 @@ export default Mixin.create({
       return true;
     }
 
-    return user.get('memberships').then(() => {
-      return user.get('currentMemberships').some(membership => membership.get('group.id') === this.get('group.id'));
-    });
+    return user.get('currentMemberships').some(membership => membership.get('group.id') === this.get('group.id'));
   }
 });


### PR DESCRIPTION
### Summary
Fixes #173 

### Other information
The problem was that `isOwner` returned a promise object which wasn't actually evaluated. Since a promise object is truthy, `isOwner` would always be resolved as `true`.
