### PR TITLE
Fix model relations and date attributes

### DIFF
--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -12,8 +12,8 @@ export default class Activity extends Model {
   @attr startTime;
   @attr endTime;
   @attr('capitalized-string') category;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
   @attr({ defaultValue: false }) publiclyVisible;
   @attr coverPhoto;
   @attr coverPhotoUrl;

--- a/app/models/debit/collection.js
+++ b/app/models/debit/collection.js
@@ -4,8 +4,8 @@ export default class Collection extends Model {
   @attr name;
   @attr date;
   @attr importFile;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relationships
   @hasMany('debit/transaction') transactions;

--- a/app/models/debit/mandate.js
+++ b/app/models/debit/mandate.js
@@ -1,8 +1,8 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class Mandate extends Model {
-  @attr startDate;
-  @attr endDate;
+  @attr('date') startDate;
+  @attr('date') endDate;
   @attr iban;
   @attr ibanHolder;
 

--- a/app/models/debit/transaction.js
+++ b/app/models/debit/transaction.js
@@ -3,8 +3,8 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 export default class Transaction extends Model {
   @attr description;
   @attr amount;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relationships
   @belongsTo user;

--- a/app/models/form/closed-question-answer.js
+++ b/app/models/form/closed-question-answer.js
@@ -2,8 +2,8 @@ import { alias } from '@ember/object/computed';
 import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class ClosedQuestionAnswer extends Model {
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @belongsTo('form/closed-question-option') option;

--- a/app/models/form/closed-question-option.js
+++ b/app/models/form/closed-question-option.js
@@ -3,8 +3,8 @@ import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 export default class ClosedQuestionOption extends Model {
   @attr option;
   @attr position;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @belongsTo('form/closed-question') question;

--- a/app/models/form/closed-question.js
+++ b/app/models/form/closed-question.js
@@ -7,8 +7,8 @@ export default class ClosedQuestion extends Model {
   @attr fieldType;
   @attr position;
   @attr required;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @belongsTo('form/form') form;

--- a/app/models/form/form.js
+++ b/app/models/form/form.js
@@ -8,8 +8,8 @@ export default class Form extends Model {
   @attr amountOfResponses;
   @attr currentUserResponseCompleted;
   @attr currentUserResponseId;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @hasMany('form/open-question') openQuestions;

--- a/app/models/form/open-question-answer.js
+++ b/app/models/form/open-question-answer.js
@@ -3,8 +3,8 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class OpenQuestionAnswer extends Model {
   @attr answer;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @belongsTo('form/open-question') question;

--- a/app/models/form/open-question.js
+++ b/app/models/form/open-question.js
@@ -5,8 +5,8 @@ export default class OpenQuestion extends Model {
   @attr fieldType;
   @attr position;
   @attr required;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @belongsTo('form/form') form;

--- a/app/models/forum/post.js
+++ b/app/models/forum/post.js
@@ -4,8 +4,8 @@ export default class Post extends Model {
   // Properties
   @attr message;
   @attr messageCamofied;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @belongsTo('user') author;

--- a/app/models/forum/thread.js
+++ b/app/models/forum/thread.js
@@ -4,9 +4,9 @@ import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 export default class Thread extends Model {
   // Properties
   @attr title;
-  @attr closedAt;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') closedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
   @attr amountOfPosts;
 
   // Relations

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -6,9 +6,9 @@ export default class Group extends Model {
   @attr kind;
   @attr description;
   @attr descriptionCamofied;
-  @attr recognizedAtGma;
-  @attr rejectedAtGma;
-  @attr createdAt;
+  @attr('date') recognizedAtGma;
+  @attr('date') rejectedAtGma;
+  @attr('date') createdAt;
   @attr({ defaultValue: false }) administrative;
   @attr avatar;
   @attr avatarUrl;
@@ -18,7 +18,7 @@ export default class Group extends Model {
   @hasMany memberships;
   @hasMany permissions;
   @hasMany({ inverse: 'group' }) mailAliases;
-  @hasMany({ inverse: 'moderatorGroup' }) moderatorForMailAliases;
+  @hasMany('mail-alias', { inverse: 'moderatorGroup' }) moderatorForMailAliases;
 
   // Getters
   get recognitionPeriod() {

--- a/app/models/mail-alias.js
+++ b/app/models/mail-alias.js
@@ -6,7 +6,7 @@ export default class MailAlias extends Model {
   @attr moderationType;
   @attr description;
   @attr({ defaultValue: false }) smtpEnabled;
-  @attr lastReceivedAt;
+  @attr('date') lastReceivedAt;
 
   // Relations
   @belongsTo({ inverse: 'mailAliases' }) user;

--- a/app/models/membership.js
+++ b/app/models/membership.js
@@ -3,11 +3,11 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class Membership extends Model {
   // Attributes
-  @attr startDate;
-  @attr endDate;
-  @attr  function;
-  @attr  createdAt;
-  @attr  updatedAt;
+  @attr('date') startDate;
+  @attr('date') endDate;
+  @attr function;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relationships
   @belongsTo user;

--- a/app/models/photo-comment.js
+++ b/app/models/photo-comment.js
@@ -3,8 +3,8 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 export default class PhotoComment extends Model {
   // Properties
   @attr content;
-  @attr updatedAt;
-  @attr createdAt;
+  @attr('date') updatedAt;
+  @attr('date') createdAt;
 
   // Relations
   @belongsTo('user') author;

--- a/app/models/photo.js
+++ b/app/models/photo.js
@@ -11,12 +11,12 @@ export default class Photo extends Model {
   @attr imageThumbUrl;
   @attr imageMediumUrl;
   @attr amountOfComments;
-  @attr updatedAt;
-  @attr  createdAt;
+  @attr('date') updatedAt;
+  @attr('date') createdAt;
 
   @attr exifMake;
   @attr exifModel;
-  @attr exifDateTimeOriginal;
+  @attr('date') exifDateTimeOriginal;
   @attr exifExposureTime;
   @attr exifApertureValue;
   @attr exifIsoSpeedRatings;

--- a/app/models/poll.js
+++ b/app/models/poll.js
@@ -3,8 +3,8 @@ import { isNone } from '@ember/utils';
 
 export default class Poll extends Model {
   // Properties
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Relations
   @belongsTo('user') author;

--- a/app/models/quickpost-message.js
+++ b/app/models/quickpost-message.js
@@ -2,7 +2,7 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class QuickpostMessage extends Model {
   @attr message;
-  @attr createdAt;
+  @attr('date') createdAt;
 
   // Relationships
   @belongsTo('user') author;

--- a/app/models/static-page.js
+++ b/app/models/static-page.js
@@ -6,7 +6,7 @@ export default class StaticPage extends Model {
   @attr content;
   @attr contentCamofied;
   @attr slug;
-  @attr createdAt;
+  @attr('date') createdAt;
   @attr({ defaultValue: false })  publiclyVisible;
   @attr category;
 }

--- a/app/models/stored-mail.js
+++ b/app/models/stored-mail.js
@@ -3,7 +3,7 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 export default class StoredMail extends Model {
   // Properties
   @attr messageUrl;
-  @attr receivedAt;
+  @attr('date') receivedAt;
   @attr subject;
   @attr plainBody;
   @attr  sender;

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -44,9 +44,9 @@ export default class User extends Model {
 
   // Technical properties
   @attr loginEnabled;
-  @attr activatedAt;
-  @attr createdAt;
-  @attr updatedAt;
+  @attr('date') activatedAt;
+  @attr('date') createdAt;
+  @attr('date') updatedAt;
 
   // Avatar
   @attr avatar;


### PR DESCRIPTION
### Summary
There were several issues with the last deploy. This PR fixes that: 
- Users could not be added to a group because of an incomplete model relation
- Date attributes were not parsed as dates. This caused user group filtering to be broken and may have caused other issues elsewhere
