### PR TITLE
Fix broken select all button on iCal page 

### DIFF
--- a/app/templates/activities/ical.hbs
+++ b/app/templates/activities/ical.hbs
@@ -19,10 +19,6 @@
               </label>
             </div>
           {{/each}}
-
-          <div class="col-sm-2">
-            <button class="btn" type="button" name="checkAll" {{action "toggleCheckAll"}}>{{if checkedAll "Deselecteer alles" "Selecteer alles" }}</button>
-          </div>
         </form>
 
         <hr>


### PR DESCRIPTION
Fixes #215 
I just removed the button, since all the checkboxes are checked by default anyways.