### PR TITLE
Remove users without thumbnail from list, improve difficulty 1 layout

### DIFF
--- a/app/controllers/sog/name-trainer.js
+++ b/app/controllers/sog/name-trainer.js
@@ -66,8 +66,8 @@ export default Controller.extend({
       this.set('groupId', model.id);
     },
     startTrainer() {
-      this.users.then(user => {
-        this.generateQuestions(user);
+      this.users.then(users => {
+        this.generateQuestions(users.filter(user => user.avatarThumbUrl));
         this.set('started', true);
         this.set('finished', false);
         this.set('currentQuestionIndex', 1);

--- a/app/styles/routes/sog/name-trainer.scss
+++ b/app/styles/routes/sog/name-trainer.scss
@@ -47,4 +47,23 @@
     width: 25px;
     height: 25px;
   }
+
+  .trainer-images {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .trainer-image {
+    flex: 50%;
+    border: 0;
+    text-align: center;
+
+    img {
+      border-radius: 50%;
+      width: 100%;
+      max-width: 200px;
+      height: auto;
+    }
+  }
 }

--- a/app/templates/sog/name-trainer.hbs
+++ b/app/templates/sog/name-trainer.hbs
@@ -21,11 +21,11 @@
           <div class="card-body text-center trainer-question">
             <h2 class="card-title">Wie is {{currentQuestion.question.fullName}}?</h2>
           </div>
-          <ul class="list-group list-group-flush trainer-options">
+          <ul class="list-group list-group-flush trainer-options trainer-images">
             {{#each currentQuestion.options as |opt|}}
-              <li class="list-group-item trainer-option {{if (and answered (eq currentQuestion.question opt))
+              <li class="list-group-item trainer-image {{if (and answered (eq currentQuestion.question opt))
                                                              "bg-success"}}" {{action 'chooseOption' opt}}>
-                <img class="card-img-rounded trainer-thumb-small" src="{{opt.avatarThumbUrlOrDefault}}">
+                <img class="card-img-rounded" src="{{opt.avatarThumbUrlOrDefault}}">
               </li>
             {{/each}}
           </ul>


### PR DESCRIPTION
### Summary
This PR improves the layout of the Easy name trainer level by showing the images in a 2x2 grid instead of a list.
Additionally, users without an avatar image are now filtered from the trainer.