### PR TITLE
Fix thread permission bug

### DIFF
--- a/app/routes/forum/categories/category/threads/thread.js
+++ b/app/routes/forum/categories/category/threads/thread.js
@@ -8,7 +8,7 @@ export default class ThreadRoute extends AuthenticatedRoute {
   }
 
   canAccess() {
-    return this.can.can('edit forum/threads');
+    return this.can.can('show forum/threads');
   }
 
   model(params) {


### PR DESCRIPTION
#262 introduced a regression where a wrong permission was being used for showing threads.

This PR resolves #267 