### PR TITLE
Fix/Poll ability checking for memberships

### DIFF
--- a/app/abilities/poll.js
+++ b/app/abilities/poll.js
@@ -14,11 +14,11 @@ export default Ability.extend({
   canDestroy: computed('session.currentUser', function() {
     return this.session.hasPermission('poll.destroy');
   }),
-  canEdit: computed('session.currentUser', 'session.currentUser.memberships', 'model', function() {
+  canEdit: computed('session.currentUser', 'model.author.id', function() {
     return this.session.hasPermission('poll.update') || this.isPollOwner(this.model);
   }),
   isPollOwner(poll) {
     const { currentUser } = this.session;
-    return !isNone(currentUser) && poll.isOwner(currentUser);
+    return !isNone(currentUser) && (poll.get('author.id') === currentUser.get('id'));
   }
 });

--- a/app/models/poll.js
+++ b/app/models/poll.js
@@ -55,12 +55,4 @@ export default class Poll extends Model {
       form?.rollbackAttributesAndQuestions();
     });
   }
-
-  isOwner(user) {
-    if (user.get('id') === this.author.get('id')) {
-      return true;
-    }
-
-    return user.currentMemberships.some(membership => membership.group.id === this.group.id);
-  }
 }


### PR DESCRIPTION
This fixes the bug where the poll.isOwner method checked if a user is member of the group the poll is made by, while a poll can be made by users only.

This PR resolves #250 & #272 
fixes AMBER-UI-PRODUCTION-TG