### PR TITLE
Fix/Form status icon name

### DIFF
--- a/app/templates/components/form/status-icon.hbs
+++ b/app/templates/components/form/status-icon.hbs
@@ -1,3 +1,3 @@
 <span class="status-icon text-{{color}} {{if (eq icon 'circle') 'small'}}">
-  <FaIcon @icon=icon/>
+  <FaIcon @icon={{icon}}/>
 </span>


### PR DESCRIPTION
The template for the form status-icon set the FaIcon iconName to "icon" instead of the variable {{icon}}. This PR fixes that, now the index pages of activities and polls show the correct icons again.

This PR resolves #273 