### PR TITLE
Allow clearing the powerselectors

### DIFF
--- a/app/templates/activities/form.hbs
+++ b/app/templates/activities/form.hbs
@@ -41,7 +41,8 @@
 
             <div class="col-sm-10">
               <PowerSelect @options={{groups}} @onChange={{action (mut @model.group)}}
-                           @selected={{@model.group}} @searchEnabled={{true}} @searchField="name" as |group|>
+                           @selected={{@model.group}} @searchEnabled={{true}} @searchField="name"
+                           @allowClear={{true}} as |group|>
                 {{group.name}}
               </PowerSelect>
 

--- a/app/templates/articles/form.hbs
+++ b/app/templates/articles/form.hbs
@@ -25,7 +25,7 @@
         <label class="col-md-2 form-control-label">Namens groep of commissie</label>
 
         <div class="col-sm-10">
-          <PowerSelect @options={{groups}} @onChange={{action (mut @model.group)}} @selected={{@model.group}} @searchEnabled={{true}} @searchField="name" as |group|>
+          <PowerSelect @options={{groups}} @onChange={{action (mut @model.group)}} @selected={{@model.group}} @searchEnabled={{true}} @searchField="name" @allowClear={{true}} as |group|>
             {{group.name}}
           </PowerSelect>
 

--- a/app/templates/debit/collections/edit.hbs
+++ b/app/templates/debit/collections/edit.hbs
@@ -18,7 +18,7 @@
       <span class="col-md-2 form-control-label">Toevoegen</span>
 
       <div class="col-sm-10">
-        <PowerSelect @options={{users}} @onChange={{action "addUser"}} @selected={{transaction.user}} @searchEnabled={{true}} @searchField="fullName" as |user|>
+        <PowerSelect @options={{users}} @onChange={{action "addUser"}} @selected={{transaction.user}} @searchEnabled={{true}} @searchField="fullName" @allowClear={{true}} as |user|>
           {{user.fullName}}
         </PowerSelect>
       </div>

--- a/app/templates/mail-aliases/form.hbs
+++ b/app/templates/mail-aliases/form.hbs
@@ -13,7 +13,8 @@
         <div class="col-sm-10">
           <PowerSelect @options={{groups}} @onChange={{action (mut @model.moderatorGroup)}}
                        @selected={{@model.moderatorGroup}} @disabled={{moderationTypeOpen}}
-                       @placeholder={{Moderator}} @searchEnabled={{true}} @searchField="name" as |group|>
+                       @placeholder={{Moderator}} @searchEnabled={{true}} @searchField="name"
+                       @allowClear={{true}} as |group|>
             {{group.name}}
           </PowerSelect>
 
@@ -27,7 +28,7 @@
         <label class="col-md-2 form-control-label">Groep</label>
 
         <div class="col-sm-10">
-          <PowerSelect @options={{groups}} @onChange={{action (mut @model.group)}} @selected={{@model.group}} @disabled={{anyUser}} @placeholder={{Groep}} @searchEnabled={{true}} @searchField="name" as |group|>
+          <PowerSelect @options={{groups}} @onChange={{action (mut @model.group)}} @selected={{@model.group}} @disabled={{anyUser}} @placeholder={{Groep}} @searchEnabled={{true}} @searchField="name" @allowClear={{true}} as |group|>
             {{group.name}}
           </PowerSelect>
 
@@ -36,10 +37,10 @@
       </div>
 
       <div class="form-group row">
-        <label class="col-md-2 form-control-label">Groep</label>
+        <label class="col-md-2 form-control-label">Gebruiker</label>
 
         <div class="col-sm-10">
-          <PowerSelect @options={{users}} @onChange={{action (mut @model.user)}} @selected={{@model.user}} @disabled={{anyGroup}} @placeholder={{Gebruiker}} @searchEnabled={{true}} @searchField="fullName" as |user|>
+          <PowerSelect @options={{users}} @onChange={{action (mut @model.user)}} @selected={{@model.user}} @disabled={{anyGroup}} @placeholder={{Gebruiker}} @searchEnabled={{true}} @searchField="fullName" @allowClear={{true}} as |user|>
             {{user.fullName}}
           </PowerSelect>
 

--- a/app/templates/users/batch/new.hbs
+++ b/app/templates/users/batch/new.hbs
@@ -15,7 +15,7 @@
       <div class="row form-group">
         <label class="col-sm-2 col-form-label form-control-label" for="group">Toevoegen aan groep</label>
         <div class="col-sm-10">
-          <PowerSelect @selected={{addToGroup}} @options={{groups}} @onChange={{action (mut addToGroup)}} @searchEnabled={{true}} @searchField="name" as |group|>
+          <PowerSelect @selected={{addToGroup}} @options={{groups}} @onChange={{action (mut addToGroup)}} @searchEnabled={{true}} @searchField="name" @allowClear={{true}} as |group|>
             {{group.name}}
           </PowerSelect>
         </div>


### PR DESCRIPTION
### Summary
Currently we cannot unset a lot of the 'Power selectors', while for some we need to be able to do it. I have added the `allowClear` option to the selectors for which I think it is useful to be able to unset the selection.

Fixes #245 