### PR TITLE
Fix abort error on oauth after login

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -19,7 +19,9 @@ export default class SessionService extends BaseSessionService {
     try {
       await this.loadUser();
     } catch(err) {
-      await this.invalidate();
+      if (err.name !== 'AbortError') {
+        await this.invalidate();
+      }
     }
   }
 


### PR DESCRIPTION
### Summary
Fixes #281 

The Oauth route does an redirect as soon as it sees that the current user has already authorized the application. However, this throws an 'abortError' in ember, which just indicates that the current transition has been aborted. This however combined with the loadUser caused it to invalidate. this PR fixes that by checking that the error is not an abortError