### PR TITLE
feat: send clientId with OAuth2 password grant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OAUTH_CLIENT_ID=<id>

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 ########
 =======
 /.env*
+!/.env.example
 /.pnp*
 /.sass-cache
 /connect.lock

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ You will need the following things properly installed on your computer.
 * change into the new directory
 * `yarn add` (or `npm install`)
 
+### OAuth Configuration
+
+In [Amber API](https://github.com/csvalpha/amber-api), execute the following command (in `rails console`):
+
+```ruby
+app = Doorkeeper::Application.create(name: 'A.M.B.E.R. - Webstek der C.S.V. Alpha', redirect_uri: 'https://example.com', scopes: 'public', confidential: false)
+app.uid
+```
+
+Next, copy `.env.example` to `.env` and enter the uid after `OAUTH_CLIENT_ID`.
+
 ## Running / Development
 
 * `ember server` or `npm start`

--- a/app/authenticators/oauth2.js
+++ b/app/authenticators/oauth2.js
@@ -4,6 +4,5 @@ import ENV from '../config/environment';
 export default class OAuth2Authenticator extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.api.hostname}/oauth/token`
   serverTokenRevocationEndpoint =`${ENV.api.hostname}/oauth/revoke`
-  rejectWithResponse = true
-  sendClientIdAsQueryParam = true
+  clientId = ENV.clientId
 }

--- a/config/dotenv.js
+++ b/config/dotenv.js
@@ -1,0 +1,14 @@
+/* eslint-env node */
+'use strict';
+
+const path = require('path');
+
+module.exports = function(env) {
+  return {
+    enabled: env === 'development',
+    clientAllowedKeys: ['OAUTH_CLIENT_ID'],
+    fastbootAllowedKeys: [],
+    failOnMissingKey: false,
+    path: path.join(path.dirname(__dirname), '.env')
+  };
+};

--- a/config/environment.js
+++ b/config/environment.js
@@ -89,6 +89,8 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
+    ENV.clientId = process.env.OAUTH_CLIENT_ID;
+
     // Disable mirage in development
     ENV['ember-cli-mirage'] = {
       enabled: false,
@@ -128,11 +130,16 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     ENV.contentSecurityPolicy['report-uri'] = 'https://sentry.io/api/186017/security/?sentry_key=5931cc6f635a4e6c96c8dcab4885485f';
-    ENV['@sentry/ember'].sentry.dsn = 'https://8936a95696f7453ab03e59264a7fede8@sentry.io/186017'
+    ENV['@sentry/ember'].sentry.dsn = 'https://8936a95696f7453ab03e59264a7fede8@sentry.io/186017';
   }
 
   if (deployTarget === 'production') {
+    ENV.clientId = ''; // TODO: set
     ENV.googleAnalytics = { webPropertyId: 'UA-8136462-4' };
+  }
+
+  if (deployTarget === 'staging') {
+    ENV.clientId = ''; // TODO: set
   }
 
   return ENV;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-cli-babel": "^7.26.3",
     "ember-cli-content-security-policy": "^1.1",
     "ember-cli-dependency-checker": "^3.2",
+    "ember-cli-dotenv": "^3.1.0",
     "ember-cli-dropzonejs": "^1.3",
     "ember-cli-file-saver": "^2.0",
     "ember-cli-htmlbars": "^5.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5718,6 +5718,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.0.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 dropzone@5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/dropzone/-/dropzone-5.5.1.tgz#06e2f513e61d6aa363d4b556f18574f47cf7ba26"
@@ -6135,6 +6140,15 @@ ember-cli-dependency-checker@^3.2:
     is-git-url "^1.0.0"
     resolve "^1.5.0"
     semver "^5.3.0"
+
+ember-cli-dotenv@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-dotenv/-/ember-cli-dotenv-3.1.0.tgz#fbb44fdc4140acd05c712f3fa32f05192007361f"
+  integrity sha512-OQ0PFQvedzeKepYDMuT8fU6dVEpieWSM3/ARlcuyO0ck+nQJ1i0m89kM1ooWAQpvUYQAJKNun1x8s38EvkEWRA==
+  dependencies:
+    dotenv "^8.0.0"
+    ember-cli-babel "^7.1.2"
+    minimist "^1.2.0"
 
 ember-cli-dropzonejs@^1.3:
   version "1.3.6"


### PR DESCRIPTION
Allows for a way to set the `clientId` sent with OAuth requests, since this is necessary with Doorkeeper v5.5.0.
This requires public (confidential: false) Doorkeeper clients to be made on the API for both `staging` and `production`, which the can be set in `environment.js`.

I added the `.env.example` and `ember-cli-dotenv` to make setting the `clientId` in development environments easier.
