### PR TITLE
fix: correctly set build args in docker-compose build config

### DIFF
--- a/docker-compose.buildkite.yml
+++ b/docker-compose.buildkite.yml
@@ -6,13 +6,16 @@ services:
       context: .
       dockerfile: Dockerfile.buildkite
 
-  app-production: &production
-    build: .
-    environment:
-      - BUILD_HASH=${BUILDKITE_COMMIT}
+  app-production:
+    build: &production-build
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - BUILD_HASH=${BUILDKITE_COMMIT}
 
   app-staging:
-    <<: *production
-    environment:
-      - DEPLOY_TARGET=staging
-      - BUILD_HASH=${BUILDKITE_COMMIT}
+    build:
+      <<: *production-build
+      args:
+        - DEPLOY_TARGET=staging
+        - BUILD_HASH=${BUILDKITE_COMMIT}


### PR DESCRIPTION
After merging https://github.com/csvalpha/amber-ui/pull/315 I found out that the `deployTarget` is not correctly set (because after deploying that PR it sent the production `client_id` instead of the staging one on staging).

This is the case because in the Dockerfile, the ARG `DEPLOY_TARGET` defaults to "production" and instead of setting the build args in `docker-compose.buildkite.yml` it sets env variables, so the ARG in the Dockerfile is never overridden.

This PR fixes that by correctly setting the build args.