### PR TITLE
Fix sepa saving

### DIFF
--- a/app/routes/debit/collections/sepa.js
+++ b/app/routes/debit/collections/sepa.js
@@ -2,7 +2,9 @@ import { AuthenticatedRoute } from 'alpha-amber/routes/application/application';
 import { inject as service } from '@ember/service';
 import { isInvalidResponse } from 'ember-fetch/errors';
 
-export default class SepaRoute extends AuthenticatedRoute {
+import FileSaverMixin from 'ember-cli-file-saver/mixins/file-saver';
+
+export default class SepaRoute extends AuthenticatedRoute.extend(FileSaverMixin) {
   breadCrumb = { title: 'Sepa downloaden' }
   @service fetch
 


### PR DESCRIPTION
### Summary
Related: #290 
When trying to export a sepa the error `this.saveFileAs is not a function` would be shown.
