### PR TITLE
Hotfix user detail page

### DIFF
--- a/app/routes/users/resend-activation.js
+++ b/app/routes/users/resend-activation.js
@@ -1,7 +1,7 @@
 import { AuthenticatedRoute } from 'alpha-amber/routes/application/application';
 
 export default class ResendActivationRoute extends AuthenticatedRoute {
-  breadCrumb = { title: `Activatiecode hersturen van ${this.controller.model.fullName}` }
+  breadCrumb = { title: 'Activatiecode hersturen' }
 
   canAccess(model) {
     return this.can.can('resend activation code of user', model);

--- a/app/templates/users/resend-activation.hbs
+++ b/app/templates/users/resend-activation.hbs
@@ -1,4 +1,4 @@
-<p>Weet je zeker dat je de activatiecode voor deze gebruiker opnieuw wil versturen? Dit zal de oude activatiecode ongeldig maken.</p>
+<p>Weet je zeker dat je de activatiecode voor {{@model.fullName}} opnieuw wil versturen? Dit zal de oude activatiecode ongeldig maken.</p>
 
 <button {{action "resendActivation"}} class="btn btn-danger" type="button">Ja</button>
 <LinkTo @route="users.show" @model={{@model.id}} class="btn btn-default" @tagName="button">Nee</LinkTo>


### PR DESCRIPTION
When a user is not activated yet, the user detail page does not load because of an error in the route of resend_activation. This PR hotfixes this.