### PR TITLE
fix: install file-saver and extend instead of reexport component

### DIFF
--- a/app/components/poll/closed-question.js
+++ b/app/components/poll/closed-question.js
@@ -1,3 +1,3 @@
-import ClosedQuestionComponent from 'alpha-amber/components/form/closed-question';
+import FormClosedQuestionComponent from 'alpha-amber/components/form/closed-question';
 
-export default ClosedQuestionComponent;
+export default class PollClosedQuestionComponent extends FormClosedQuestionComponent {};

--- a/app/components/poll/closed-question.js
+++ b/app/components/poll/closed-question.js
@@ -1,3 +1,3 @@
 import FormClosedQuestionComponent from 'alpha-amber/components/form/closed-question';
 
-export default class PollClosedQuestionComponent extends FormClosedQuestionComponent {};
+export default class PollClosedQuestionComponent extends FormClosedQuestionComponent {}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-ember-suave": "^2.0",
     "eslint-plugin-node": "^11.1",
     "faker": "^5.5.3",
+    "file-saver": "^2.0.5",
     "glob": "^7.1",
     "http-proxy": "^1.18",
     "loader.js": "^4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,6 +3938,7 @@ __metadata:
     eslint-plugin-ember-suave: ^2.0
     eslint-plugin-node: ^11.1
     faker: ^5.5.3
+    file-saver: ^2.0.5
     glob: ^7.1
     http-proxy: ^1.18
     loader.js: ^4.7
@@ -11151,6 +11152,13 @@ __metadata:
   dependencies:
     flat-cache: ^3.0.4
   checksum: f49701feaa6314c8127c3c2f6173cfefff17612f5ed2daaafc6da13b5c91fd43e3b2a58fd0d63f9f94478a501b167615931e7200e31485e320f74a33885a9c74
+  languageName: node
+  linkType: hard
+
+"file-saver@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "file-saver@npm:2.0.5"
+  checksum: c62d96e5cebc58b4bdf3ae8a60d5cf9607ad82f75f798c33a4ee63435ac2203002584d5256a2a780eda7feb5e19dc3b6351c2212e58b3f529e63d265a7cc79f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
After the mixins PR was reviewed, a staging into PR branch merge commit (36c67015201e3094dc6ec8ef4962e85bf82019e3) somehow removed `file-saver` from the dependencies. I'm very confused as to why this happened, this PR adds it again!
