### PR TITLE
PWA icons

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -29,6 +29,11 @@ module.exports = function(defaults) {
     babel: {
       plugins: [require.resolve('@babel/plugin-proposal-optional-chaining')],
       sourceMaps: 'inline'
+    },
+
+    fingerprint: {
+      extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg'],
+      replaceExtensions: ['html', 'css', 'js', 'json']
     }
   });
 


### PR DESCRIPTION
### Summary
Currently, the icons in the manifest.json are not working because they are fingerprinted (a hash is added to the filename). I added json files to the list of files in which to replace filenames with the fingerprinted versions to fix this. While I was at it, I also added svgs to the list of files to fingerprint. See https://cli.emberjs.com/release/advanced-use/asset-compilation/#fingerprintingandcdnurls for info on fingerprinting.