### PR TITLE
Static pages bugfixes

### DIFF
--- a/app/controllers/static-pages/index.js
+++ b/app/controllers/static-pages/index.js
@@ -1,7 +1,9 @@
 import FilterableAndSortableController from 'alpha-amber/controllers/application/filterable-and-sortable';
 import { inject as service } from '@ember/service';
-import groupBy from 'ember-group-by';
+import { computed, get } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
+import { isPresent } from '@ember/utils';
 
 export default class StaticPagesIndexController extends FilterableAndSortableController {
   @service session
@@ -18,5 +20,25 @@ export default class StaticPagesIndexController extends FilterableAndSortableCon
     }
   ]
 
-  groupedModel = groupBy('model', 'category')
+  get groupedModel() {
+    // https://github.com/HeroicEric/ember-group-by/blob/057e3c0129cc58885c94708e839cda5f8f34afb9/addon/macros/group-by.js#L9
+    let groups = A();
+    let items = this.model;
+
+    if (items) {
+      items.forEach(function(item) {
+        let value = item.category;
+        let group = groups.findBy('value', value);
+
+        if (isPresent(group)) {
+          group.items.push(item);
+        } else {
+          group = { property: 'category', value, items: [item] };
+          groups.push(group);
+        }
+      });
+    }
+
+    return groups;
+  }
 }

--- a/app/routes/static-pages/new.js
+++ b/app/routes/static-pages/new.js
@@ -8,7 +8,7 @@ export default class NewStaticPageRoute extends AuthenticatedRoute {
   }
 
   model() {
-    return this.store.createRecord('mail-alias');
+    return this.store.createRecord('static-page');
   }
 
   deactivate() {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "ember-data": "~3.20.0",
     "ember-fetch": "^8.0",
     "ember-file-upload": "^4.0.3",
-    "ember-group-by": "^0.0",
     "ember-intl": "^5.1",
     "ember-keyboard-shortcuts": "^1.2",
     "ember-link-action": "^2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,7 +3912,6 @@ __metadata:
     ember-data: ~3.20.0
     ember-fetch: ^8.0
     ember-file-upload: ^4.0.3
-    ember-group-by: ^0.0
     ember-intl: ^5.1
     ember-keyboard-shortcuts: ^1.2
     ember-link-action: ^2.0
@@ -9471,15 +9470,6 @@ __metadata:
     ember-cli-version-checker: ^2.1.0
     ember-factory-for-polyfill: ^1.3.1
   checksum: c448df6974a559401b1f86c74f681d8e05d50f0217c5e9c03720177005c936903faa8962df3f8766b68339a0ea34ef781ecabe322c9965b45118011c2642bc23
-  languageName: node
-  linkType: hard
-
-"ember-group-by@npm:^0.0":
-  version: 0.0.6
-  resolution: "ember-group-by@npm:0.0.6"
-  dependencies:
-    ember-cli-babel: ^6.6.0
-  checksum: a577bcc391ef17d97eebe5723f5eb17f6f8bafa7007f24fed6d38dad3a6149bc872024a3199c4cb86f49601d8a072cece353f5bb0dfcd7f2efc8f905274b79ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
Fixes #452 
I removed the ember-group-by dependency since the computed property it uses is no longer supported in octane. I copied the implementation of the library to our own code since the groupBy is only used in one place.
I also fixed a bug related to new static page routing which has apparently already been in our code for a long time.