### PR TITLE
Fix archived user filter

### DIFF
--- a/app/routes/users/index.js
+++ b/app/routes/users/index.js
@@ -25,7 +25,6 @@ export default class UserIndexRoute extends AuthenticatedRoute {
   }
 
   model(params) {
-    params = assign({ 'filter': { 'archived': false } }, params);
     params.perPage = 12;
     return this.store.queryPaged('user', params);
   }

--- a/app/routes/users/index.js
+++ b/app/routes/users/index.js
@@ -1,5 +1,4 @@
 import { AuthenticatedRoute } from 'alpha-amber/routes/application/application';
-import { assign } from '@ember/polyfills';
 
 export default class UserIndexRoute extends AuthenticatedRoute {
   breadCrumb = { title: 'Gebruikers' }


### PR DESCRIPTION
### Summary
Because of https://github.com/csvalpha/amber-api/pull/259 there is no need to filter out archived users anymore.