### PR TITLE
feat: add docker-compose.development.yml

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  web:
+    build:
+      context: .
+      target: base
+    environment:
+      - API_HOST=http://api:3000
+    ports:
+      - '4200:4200' # Ember server
+      - '7020:7020' # Livereload server
+      - '7357:7357' # Test server
+    volumes:
+      - .:/opt/app
+      - node_modules:/opt/app/node_modules
+    tmpfs:
+      - /opt/app/tmp
+    networks:
+      - amber_development_default
+
+volumes:
+  node_modules:
+
+networks:
+  amber_development_default:
+    external: true

--- a/server/proxies/api.js
+++ b/server/proxies/api.js
@@ -14,11 +14,11 @@ module.exports = function(app) {
   });
 
   app.use(proxyPath, (req, res) => {
-    proxy.web(req, res, { target: 'http://localhost:3000' });
+    proxy.web(req, res, { target: process.env.API_HOST || 'http://localhost:3000' });
   });
 
   app.use(passthroughPaths, (req, res) => {
     req.url = req.originalUrl;
-    proxy.web(req, res, { target: 'http://localhost:3000' });
+    proxy.web(req, res, { target: process.env.API_HOST || 'http://localhost:3000' });
   });
 };


### PR DESCRIPTION
### Summary
Another attempt at #235, ~~but live reloading works this time :tada:~~.

Adds Docker Compose configuration `docker-compose.development.yml` that allows to run the project in Docker.
The external network refers to the network created by the `docker-compose.development.yml` on amber-api, when that project is started with `docker-compose -f docker-compose.development.yml up` (same command can be used here), it will have created the network `amber_development_default` and containers `api` and `db` on it, which then the environment variable here can refer to.