### PR TITLE
Fix redirect after destroy

### DIFF
--- a/app/controllers/application/destroy.js
+++ b/app/controllers/application/destroy.js
@@ -1,17 +1,19 @@
 import { isNone } from '@ember/utils';
 import EditController from 'alpha-amber/controllers/application/edit';
+import ModelSaveUtil from 'alpha-amber/utils/model-save';
 
 export default EditController.extend({
   successMessage: 'Verwijderen gelukt!',
   actions: {
     destroy() {
+      let modelSaveUtil = new ModelSaveUtil(this);
       this.set('errorMessage', null);
 
       if (!isNone(this.model)) {
         this.model.destroyRecord().then(() => {
-          this.send('onSuccess');
+          modelSaveUtil.onSuccess();
         }).catch(error => {
-          this.send('onError', error);
+          modelSaveUtil.onError(error);
         });
       }
     },


### PR DESCRIPTION
### Summary
When you destroy a model (e.g. activity), currently it does not redirect you back to the index of that model, but instead it stays on the destroy confirmation page. This PR fixes that.
