### PR TITLE
Add data: to img-src in CSP

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -6,7 +6,7 @@ module.exports = function(environment) {
     'script-src': ['\'self\'', 'www.google-analytics.com', 'www.googletagmanager.com'],
     'font-src': ['\'self\'', 'fonts.gstatic.com'],
     'connect-src': ['\'self\'', 'sentry.io'],
-    'img-src': ['\'self\'', 'camo.csvalpha.nl', 'www.google-analytics.com', 'img.youtube.com'],
+    'img-src': ['\'self\'', 'camo.csvalpha.nl', 'www.google-analytics.com', 'img.youtube.com', 'data:'],
     'style-src': ['\'self\'', '\'unsafe-inline\'', 'fonts.googleapis.com/'],
     'media-src': ['\'self\''],
     'manifest-src': ['\'self\''],


### PR DESCRIPTION
### Summary
This PR adds `data:` to the list of allowed `img-src`s in the CSP such that the base64 data images in e.g. the article cover upload preview can be shown. Since this only allows inline data in img context this should pose no inherent security risk.

Before fix:
![image](https://user-images.githubusercontent.com/7385023/153773036-9ac64b46-149a-40b5-a21a-4dca23f0727b.png)

After fix it previews the uploaded image.
