### PR TITLE
fix(EditController): correctly bind this to modelSaveUtil

### DIFF
--- a/app/controllers/application/destroy.js
+++ b/app/controllers/application/destroy.js
@@ -12,8 +12,8 @@ export default EditController.extend({
       if (!isNone(this.model)) {
         this.model
           .destroyRecord()
-          .then(modelSaveUtil.onSuccess)
-          .catch(modelSaveUtil.onError);
+          .then(modelSaveUtil.onSuccess.bind(modelSaveUtil))
+          .catch(modelSaveUtil.onError.bind(modelSaveUtil));
       }
     },
     saveModel: undefined,


### PR DESCRIPTION
### Summary

`this` argument is not correctly bound to the modelSaveUtil method calls, this PR fixes that.

### Other information

https://sentry.io/organizations/csvalpha/issues/3095718738/?project=186017&referrer=slack
