### PR TITLE
fix: mark potential member info as htmlSafe

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -5,9 +5,6 @@ module.exports = {
   rules: {
     'no-bare-strings': false,
     'block-indentation': 2,
-    'no-html-comments': true,
-    'no-triple-curlies': true,
-    'no-shadowed-elements': true,
     // TODO: activate those
     'no-implicit-this': false,
     'require-valid-alt-text': false,

--- a/app/components/index/public/potential-member-section.hbs
+++ b/app/components/index/public/potential-member-section.hbs
@@ -2,7 +2,9 @@
   <div class='container text-xl text-white'>
     <p>{{t 'component.index.public.potentialMember.title'}}</p>
     <div class='info-text'>
-      <p class='mb-0'>{{t 'component.index.public.potentialMember.info'}}</p>
+      <p class='mb-0'>
+        {{html-safe (t 'component.index.public.potentialMember.info')}}
+      </p>
       <br />
     </div>
   </div>

--- a/app/helpers/html-safe.js
+++ b/app/helpers/html-safe.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe as emberHtmlSafe } from '@ember/template';
+
+export function htmlSafe([text]) {
+  return emberHtmlSafe(text);
+}
+
+export default helper(htmlSafe);


### PR DESCRIPTION
### Summary

Fixes #536.
Also removed some rules from `.template-lintrc.js` as they are already enabled in the `recommended` configuration that ours is extending.
