### PR TITLE
Fix CSP with SW

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -9,7 +9,16 @@ module.exports = function (environment) {
       'www.googletagmanager.com',
     ],
     'font-src': ["'self'", 'fonts.gstatic.com'],
-    'connect-src': ["'self'", 'sentry.io'],
+    'connect-src': [
+      "'self'",
+      'www.google-analytics.com',
+      'www.googletagmanager.com',
+      'sentry.io',
+      'camo.csvalpha.nl',
+      'www.google-analytics.com',
+      'img.youtube.com',
+      'fonts.googleapis.com/'
+    ],
     'img-src': [
       "'self'",
       'camo.csvalpha.nl',


### PR DESCRIPTION
This PR fixes some request that were blocked after adding a service worker (#449), which among others broke some images on the website.
Because our service worker intercepts requests to check if they are in the cache (https://github.com/csvalpha/amber-ui/blob/0d63b1e7272da0a5cedeaca9b7c05af6c7444538/public/sw.js#L16) and re-executes a fetch request after this, some other sources need to be added to the `connect-src` of the CSP. Also see 
https://stackoverflow.com/questions/68920588/content-security-policy-chrome-logs-connect-src-error-for-image-resource