### PR TITLE
fix(renovate.json5): add wait instruction to ember-cli patch PRs too

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,8 +50,8 @@
       "groupName": "ember-cli",
       "separateMinorPatch": true,
       "draftPR": true,
-      "prBodyNotes": "{{#unless isPatch}}### Upgrade Instructions\n\
-* Wait until both `danlynn/ember-cli` and `ember-cli` have the same update\n\
+      "prBodyNotes": "### Upgrade Instructions\n\
+* Wait until both `danlynn/ember-cli` and `ember-cli` have the same update{{#unless isPatch}}\n\
 * Then follow this guide: https://cli.emberjs.com/release/basic-use/upgrading/#upgradinganemberappitself\n\
 * Finally, make sure any package that was added to `package.json` by this process is added to `ignoreDeps` in [`renovate.json5`](https://github.com/csvalpha/amber-ui/blob/staging/.github/renovate.json5){{/unless}}"
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-auto-import": "^2.2.4",
     "ember-bootstrap": "^5.1.1",
     "ember-can": "^4.2.0",
-    "ember-cli": "~3.28.6",
+    "ember-cli": "~3.28.5",
     "ember-cli-babel": "^7.26.10",
     "ember-cli-content-security-policy": "^2.0.3",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9078,8 +9078,8 @@ __metadata:
   linkType: hard
 
 "ember-cli@npm:~3.28.5":
-  version: 3.28.6
-  resolution: "ember-cli@npm:3.28.6"
+  version: 3.28.5
+  resolution: "ember-cli@npm:3.28.5"
   dependencies:
     "@babel/core": ^7.13.8
     "@babel/plugin-transform-modules-amd": ^7.12.1
@@ -9174,7 +9174,7 @@ __metadata:
     yam: ^1.0.0
   bin:
     ember: bin/ember
-  checksum: 72259548e44db86ba485f0f3e249205871b866ceb40d3fc51fded957f14efd5c445d3656f7c54c02a90610587c3ba94eb034d997c9d1b84529aed212d730f5f3
+  checksum: 01badab6239582566bfa66473fd9362557bebba739e893c7e82c47a4d98ea042e3f14a3973dca73bb1463d9b3fdebae98b0398aea3122d666f581a13ab1210c8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3610,7 +3610,7 @@ __metadata:
     ember-auto-import: ^2.2.4
     ember-bootstrap: ^5.1.1
     ember-can: ^4.2.0
-    ember-cli: ~3.28.6
+    ember-cli: ~3.28.5
     ember-cli-babel: ^7.26.10
     ember-cli-content-security-policy: ^2.0.3
     ember-cli-dependency-checker: ^3.2.0
@@ -9077,7 +9077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli@npm:~3.28.6":
+"ember-cli@npm:~3.28.5":
   version: 3.28.6
   resolution: "ember-cli@npm:3.28.6"
   dependencies:


### PR DESCRIPTION
### Summary

After #621 ember-cli used to build the project locally is out of sync with the ember-cli version used in the Docker container. This PR changes the PR body on ember-cli patch updates so that the wait instruction is included here too.
