### PR TITLE
Update Flux contact info in footer

### DIFF
--- a/app/components/footer-nav.hbs
+++ b/app/components/footer-nav.hbs
@@ -112,46 +112,6 @@
               <tbody>
                 <tr>
                   <td class='footer-table-cell'>
-                    <FaIcon @icon='envelope' />
-                  </td>
-                  <td class='footer-table-cell'>
-                    <a
-                      class='footer-text'
-                      href='mailto:secretaris@societeitflux.nl'
-                      itemprop='email'
-                      content='secretaris@societeitflux.nl'
-                    >
-                      secretaris@societeitflux.nl
-                    </a>
-                  </td>
-                </tr>
-
-                <tr
-                  itemprop='contactPoint'
-                  itemscope
-                  itemtype='https://schema.org/ContactPoint'
-                >
-                  <td class='footer-table-cell'>
-                    <FaIcon
-                      @icon='phone'
-                      itemprop='contactType'
-                      content='customer support'
-                    />
-                  </td>
-                  <td class='footer-table-cell'>
-                    <a
-                      class='footer-text'
-                      href='tel:+31612234738'
-                      itemprop='telephone'
-                      content='+31612234738'
-                    >
-                      06-12234738
-                    </a>
-                  </td>
-                </tr>
-
-                <tr>
-                  <td class='footer-table-cell'>
                     <FaIcon @icon='location-dot' />
                   </td>
                   <td class='footer-table-cell'>
@@ -175,10 +135,25 @@
                     <a
                       class='footer-text'
                       itemprop='url'
-                      href='http://www.societeitflux.nl'
+                      href='https://societeitflux.nl'
                       target='_blank'
                     >
                       www.societeitflux.nl
+                    </a>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td class='footer-table-cell'>
+                    <FaIcon @icon='phone' />
+                  </td>
+                  <td class='footer-table-cell'>
+                    <a
+                      class='footer-text'
+                      href='https://societeitflux.nl/#/contact'
+                      target='_blank'
+                    >
+                      Neem contact op
                     </a>
                   </td>
                 </tr>

--- a/app/components/footer-nav.hbs
+++ b/app/components/footer-nav.hbs
@@ -15,7 +15,7 @@
               <meta itemprop='url' content='https://csvalpha.nl' />
               <meta itemprop='logo' content='/images/alphalogo.svg' />
 
-              <table class='table table-sm mw-100'>
+              <table class='table table-sm'>
                 <tbody>
                   <tr>
                     <td class='footer-table-cell'>

--- a/app/components/footer-nav.hbs
+++ b/app/components/footer-nav.hbs
@@ -15,7 +15,7 @@
               <meta itemprop='url' content='https://csvalpha.nl' />
               <meta itemprop='logo' content='/images/alphalogo.svg' />
 
-              <table class='table table-sm'>
+              <table class='table table-sm mw-100'>
                 <tbody>
                   <tr>
                     <td class='footer-table-cell'>
@@ -108,7 +108,7 @@
             <h5 class='footer-header' itemprop='name'>
               Stichting Sociëteit Flux
             </h5>
-            <table class='table table-sm'>
+            <table class='table table-sm mw-100'>
               <tbody>
                 <tr>
                   <td class='footer-table-cell'>

--- a/app/components/footer-nav.hbs
+++ b/app/components/footer-nav.hbs
@@ -112,23 +112,6 @@
               <tbody>
                 <tr>
                   <td class='footer-table-cell'>
-                    <FaIcon @icon='location-dot' />
-                  </td>
-                  <td class='footer-table-cell'>
-                    <a
-                      class='footer-text'
-                      href='https://maps.google.com/?q=Oude Markt 24-3,7511GB,Enschede'
-                      target='_blank'
-                    >
-                      <span itemprop='address'>
-                        Oude Markt 24-3 - 7511 GB Enschede
-                      </span>
-                    </a>
-                  </td>
-                </tr>
-
-                <tr>
-                  <td class='footer-table-cell'>
                     <FaIcon @icon='globe' />
                   </td>
                   <td class='footer-table-cell'>
@@ -154,6 +137,23 @@
                       target='_blank'
                     >
                       Neem contact op
+                    </a>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td class='footer-table-cell'>
+                    <FaIcon @icon='location-dot' />
+                  </td>
+                  <td class='footer-table-cell'>
+                    <a
+                      class='footer-text'
+                      href='https://maps.google.com/?q=Oude Markt 24-3,7511GB,Enschede'
+                      target='_blank'
+                    >
+                      <span itemprop='address'>
+                        Oude Markt 24-3 - 7511 GB Enschede
+                      </span>
                     </a>
                   </td>
                 </tr>


### PR DESCRIPTION
### Summary

Often, the phone number of Flux is called when somebody wants to contact Alpha. This PR replaces the contact info of flux with a link to the website of Flux, so that the differentiation Alpha<>Flux is hopefully a bit clearer. 
