### PR TITLE
Ameliorate forum-post-new reactivity

### DIFF
--- a/app/components/forum/forum-post-new.hbs
+++ b/app/components/forum/forum-post-new.hbs
@@ -1,5 +1,5 @@
 <p class='card-text'>
-  <MdEditor @content={{content}} @textareaId='newForumPost' />
+  <MdEditor @content={{this.content}} @textareaId='newForumPost' />
 </p>
 <div class='card-footer'>
   <div class='row justify-content-end'>

--- a/app/components/forum/forum-post-new.js
+++ b/app/components/forum/forum-post-new.js
@@ -1,5 +1,5 @@
 import { inject as service } from '@ember/service';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 // todo: incorporate the model-save-util into components?
@@ -7,9 +7,17 @@ export default class ForumPostNewComponent extends Component {
   @service store;
   @service flashNotice;
 
+  get content() {
+    return this.args.content;
+  }
+
+  set content(content) {
+    this.args.onChangeContent(content);
+  }
+
   @action
   async save() {
-    let { content, thread } = this;
+    let { content, thread } = this.args;
     await this.store
       .createRecord('forum/post', {
         message: content,
@@ -17,8 +25,8 @@ export default class ForumPostNewComponent extends Component {
       })
       .save();
     this.flashNotice.sendSuccess('Forumbericht toegevoegd!');
-    this.set('content', '');
-    this.onSubmit();
+    this.content = '';
+    this.args.onSubmit();
   }
 
   @action

--- a/app/controllers/forum/categories/category/threads/thread/posts/index.js
+++ b/app/controllers/forum/categories/category/threads/thread/posts/index.js
@@ -7,8 +7,7 @@ import { tracked } from '@glimmer/tracking';
 export default class PostsIndexController extends Controller {
   @service session;
   @service store;
-  @tracked
-  newContent = '';
+  @tracked newContent = '';
 
   queryParams = ['page'];
 
@@ -55,8 +54,12 @@ export default class PostsIndexController extends Controller {
 
   @action
   async addQuote(q) {
-    this.set('newContent', `${this.newContent}${q} \n\n`);
-
+    if (!this.newContent?.endsWith('\n')) {
+      // insert a newline in between if necessary
+      this.newContent = `${this.newContent}\n${q} \n\n`;
+    } else {
+      this.newContent = `${this.newContent}${q} \n\n`;
+    }
     if (!this.currentPageIsLastPage) {
       await this.transitionToRoute({
         queryParams: { page: this.model.postsPaged.meta.totalPages },
@@ -67,6 +70,11 @@ export default class PostsIndexController extends Controller {
     } else {
       this.scrollToNewForumPost();
     }
+  }
+
+  @action
+  setNewContent(content) {
+    this.newContent = content;
   }
 
   @action

--- a/app/templates/forum/categories/category/threads/thread/posts/index.hbs
+++ b/app/templates/forum/categories/category/threads/thread/posts/index.hbs
@@ -38,8 +38,9 @@
       <div class='card-body'>
         <Forum::ForumPostNew
           @thread={{@model}}
-          @content={{newContent}}
-          @onSubmit={{action 'newPostCreated'}}
+          @content={{this.newContent}}
+          @onChangeContent={{this.setNewContent}}
+          @onSubmit={{this.newPostCreated}}
         />
       </div>
     </div>


### PR DESCRIPTION
ref #641 
rewrote to glimmer component, because I understand them better, and it allows me to use the `this.args` namespace (see https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/#toc_benefits-of-glimmer-components)
note that args are immutable in glimmer components, which requires an extra function to be passed as an argument. Via this function `onChangeContent` we can pass the new value up to the containing controller, in this case `posts/index`
(If you're familiar with Vue.js then this pattern should look familiar.)

This would be fixed when #539 is finished, but I thought it wouldn't hurt to fix this since creating forum post is still broken right now