### PR TITLE
Fix error in activity always showing

### DIFF
--- a/app/controllers/activities/edit.js
+++ b/app/controllers/activities/edit.js
@@ -24,7 +24,7 @@ export default class EditActivityController extends EditController {
   get combinedErrors() {
     const combined = union(
       this.model.errors.content,
-      this.model.form?.get('errors')?.content
+      this.model.form?.get('errors')?.content ?? []
     );
     return combined.length > 0 ? combined : null;
   }


### PR DESCRIPTION
### Summary

Activity forms currently always show an empty error if there is no error. This PR fixes that
![image](https://user-images.githubusercontent.com/7385023/207643554-563f7c61-5a17-40bd-86bd-ae4d2aba2a78.png)

