### PR TITLE
Set type date for pikaday date input

### DIFF
--- a/app/components/input/date-input.hbs
+++ b/app/components/input/date-input.hbs
@@ -23,5 +23,6 @@
     disabled={{@disabled}}
     autocomplete='off'
     class={{@inputClass}}
+    type='date'
   />
 {{/if}}


### PR DESCRIPTION
fixes bug I just found, where on desktop it wasn't possible to use the date picker for date inputs, at least in firefox and chromium.