### PR TITLE
Removed deletion blocking when activity or poll has responses

### DIFF
--- a/app/templates/activities/destroy.hbs
+++ b/app/templates/activities/destroy.hbs
@@ -3,36 +3,23 @@
     <h5>Activiteit verwijderen</h5>
   </div>
   <div class='card-block p-3'>
-    {{#if @model.hasResponses}}
-      <div class='alert alert-danger'>
-        Je kunt deze activiteit niet verwijderen, omdat er al reacties zijn!
-      </div>
-      <LinkTo
-        @route='activities.show'
-        @model={{model.id}}
-        class='btn btn-default'
-      >
-        Terug
-      </LinkTo>
-    {{else}}
-      <p>
-        Weet je zeker dat je deze activiteit ({{@model.title}}) wilt
-        verwijderen?
-      </p>
+    <p>
+      Weet je zeker dat je deze activiteit ({{@model.title}}) wilt
+      verwijderen?
+    </p>
 
-      <button {{action 'destroyModel'}} class='btn btn-danger' type='button'>
-        Verwijderen
-      </button>
-      <button
-        {{action 'cancel'}}
-        type="button"
-        class='btn btn-default'
-      >
-        Annuleren
-      </button>
-      {{#if errorMessage}}
-        <div class='text-danger'>{{this.errorMessage}}</div>
-      {{/if}}
+    <button {{action 'destroyModel'}} class='btn btn-danger' type='button'>
+      Verwijderen
+    </button>
+    <button
+      {{action 'cancel'}}
+      type="button"
+      class='btn btn-default'
+    >
+      Annuleren
+    </button>
+    {{#if errorMessage}}
+      <div class='text-danger'>{{this.errorMessage}}</div>
     {{/if}}
   </div>
 </div>

--- a/app/templates/polls/destroy.hbs
+++ b/app/templates/polls/destroy.hbs
@@ -1,22 +1,20 @@
-{{#if @model.hasResponses}}
-  <div class='alert alert-danger'>
-    Je kunt deze poll niet verwijderen, omdat er al reacties zijn!
+<div class='card'>
+  <div class='card-header'>
+    <h5>Poll verwijderen</h5>
   </div>
-  <LinkTo @route='polls.show' @model={{model.id}} class='btn btn-default'>
-    Terug
-  </LinkTo>
-{{else}}
-  <p>
-    Weet je zeker dat je deze poll ({{@model.question.question}}) wilt
-    verwijderen?
-  </p>
+  <div class='card-block p-3'>
+    <p>
+      Weet je zeker dat je deze poll ({{@model.question.question}}) wilt
+      verwijderen?
+    </p>
 
-  <button {{action 'destroyModel'}} class='btn btn-danger' type='button'>Ja</button>
-  <LinkTo @route='polls.show' @model={{model.id}} class='btn btn-default'>
-    Nee
-  </LinkTo>
+    <button {{action 'destroyModel'}} class='btn btn-danger' type='button'>Ja</button>
+    <LinkTo @route='polls.show' @model={{model.id}} class='btn btn-default'>
+      Nee
+    </LinkTo>
 
-  {{#if errorMessage}}
-    <div class='text-danger'>{{this.errorMessage}}</div>
-  {{/if}}
-{{/if}}
+    {{#if errorMessage}}
+      <div class='text-danger'>{{this.errorMessage}}</div>
+    {{/if}}
+  </div>
+</div>


### PR DESCRIPTION
There was code in the templates that did not show the deletion button in the deletion confirmation winow if the acctivity or poll has responses. However, that code did not work anymore and we decided we did not want this behaviour anyways. So the code was removed.