### PR TITLE
Fix node 18 problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
   },
   "resolutions": {
     "@embroider/macros": "^1.0.0",
+    "fast-sourcemap-concat": "ef4/fast-sourcemap-concat",
     "workerpool@^2.3.0": "^2.3.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "resolutions": {
     "@embroider/macros": "^1.0.0",
-    "fast-sourcemap-concat": "ef4/fast-sourcemap-concat",
+    "fast-sourcemap-concat": "ef4/fast-sourcemap-concat#ec9dc9981503f2e56d2233430681866741bc170c",
     "workerpool@^2.3.0": "^2.3.4"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11653,7 +11653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-fast-sourcemap-concat@ef4/fast-sourcemap-concat:
+"fast-sourcemap-concat@ef4/fast-sourcemap-concat#ec9dc9981503f2e56d2233430681866741bc170c":
   version: 2.1.0
   resolution: "fast-sourcemap-concat@https://github.com/ef4/fast-sourcemap-concat.git#commit=ec9dc9981503f2e56d2233430681866741bc170c"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2635,6 +2635,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jacobq/source-map@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@jacobq/source-map@npm:1.1.0"
+  dependencies:
+    whatwg-url: ^11.0.0
+  checksum: 6173f7048abb876d3613a1921e26e20c536d0037fcae17ca740a2a5e6e6d3d7e82f56b5f1564198304f8091124b86902e36b7fc7983a11dc520facde94d29dc4
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.3
   resolution: "@jridgewell/gen-mapping@npm:0.3.3"
@@ -11644,19 +11653,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-sourcemap-concat@npm:^2.1.0":
+fast-sourcemap-concat@ef4/fast-sourcemap-concat:
   version: 2.1.0
-  resolution: "fast-sourcemap-concat@npm:2.1.0"
+  resolution: "fast-sourcemap-concat@https://github.com/ef4/fast-sourcemap-concat.git#commit=ec9dc9981503f2e56d2233430681866741bc170c"
   dependencies:
+    "@jacobq/source-map": ^1.1.0
     chalk: ^2.0.0
     fs-extra: ^5.0.0
     heimdalljs-logger: ^0.1.9
     memory-streams: ^0.1.3
     mkdirp: ^0.5.0
-    source-map: ^0.4.2
     source-map-url: ^0.3.0
     sourcemap-validator: ^1.1.0
-  checksum: d8ee2f37ec483f4ff30988186497652e065df81f2286c3f11e2934209736d3662d9f8140d8d1d41cfb9529aff9f1a9a7960d08ac2d92f6fb2ffba3358f32f4d4
+  checksum: ffd648f2e4e44249c48759d3c3bd392f8b3012c311f474873502b796c4840ab6bcd11df7ae7474b4715c6f3ae99e796a5637f59ddcc80fa71f6f6d992d06b733
   languageName: node
   linkType: hard
 
@@ -20555,7 +20564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:0.4.x, source-map@npm:^0.4.2":
+"source-map@npm:0.4.x":
   version: 0.4.4
   resolution: "source-map@npm:0.4.4"
   dependencies:
@@ -20588,9 +20597,9 @@ __metadata:
   linkType: hard
 
 "source-map@npm:~0.7.2":
-  version: 0.7.3
-  resolution: "source-map@npm:0.7.3"
-  checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
+  version: 0.7.4
+  resolution: "source-map@npm:0.7.4"
+  checksum: 01cc5a74b1f0e1d626a58d36ad6898ea820567e87f18dfc9d24a9843a351aaa2ec09b87422589906d6ff1deed29693e176194dc88bcae7c9a852dc74b311dbf5
   languageName: node
   linkType: hard
 
@@ -21791,6 +21800,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "tr46@npm:3.0.0"
+  dependencies:
+    punycode: ^2.1.1
+  checksum: 44c3cc6767fb800490e6e9fd64fd49041aa4e49e1f6a012b34a75de739cc9ed3a6405296072c1df8b6389ae139c5e7c6496f659cfe13a04a4bff3a1422981270
+  languageName: node
+  linkType: hard
+
 "tr46@npm:~0.0.3":
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
@@ -22586,6 +22604,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "webidl-conversions@npm:7.0.0"
+  checksum: f05588567a2a76428515333eff87200fae6c83c3948a7482ebb109562971e77ef6dc49749afa58abb993391227c5697b3ecca52018793e0cb4620a48f10bd21b
+  languageName: node
+  linkType: hard
+
 "webpack-sources@npm:^1.4.0, webpack-sources@npm:^1.4.1":
   version: 1.4.3
   resolution: "webpack-sources@npm:1.4.3"
@@ -22700,6 +22725,16 @@ __metadata:
   version: 3.6.2
   resolution: "whatwg-fetch@npm:3.6.2"
   checksum: ee976b7249e7791edb0d0a62cd806b29006ad7ec3a3d89145921ad8c00a3a67e4be8f3fb3ec6bc7b58498724fd568d11aeeeea1f7827e7e1e5eae6c8a275afed
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "whatwg-url@npm:11.0.0"
+  dependencies:
+    tr46: ^3.0.0
+    webidl-conversions: ^7.0.0
+  checksum: ed4826aaa57e66bb3488a4b25c9cd476c46ba96052747388b5801f137dd740b73fde91ad207d96baf9f17fbcc80fc1a477ad65181b5eb5fa718d27c69501d7af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, building Ember fails because of problems with source-map on Node 18. This PR fixes that. See https://github.com/ef4/fast-sourcemap-concat/pull/66 for more information. That PR is not in a named release of fast-sourcemap-concat yet, so for now, we change the resolution of fast-sourcemap-concat to the specific commit on its Github repo that fixed this issue