### PR TITLE
Fix: enable externally viewing activities

### DIFF
--- a/app/components/cards/activity-card.hbs
+++ b/app/components/cards/activity-card.hbs
@@ -13,25 +13,27 @@
       {{/if}}
 
       <div class='card-title-bar gradient-overlay'>
-        <div class='hidden-xs-down'>
-          {{#if activity.group}}
-            <img
-              src='{{activity.group.avatarThumbUrlOrDefault}}'
-              class='profile-picture-medium profile-picture-margin'
-              alt='{{activity.group.fullName}}'
-              height='60px'
-              style='display: inline;'
-            />
-          {{else}}
-            <img
-              src='{{activity.author.avatarThumbUrlOrDefault}}'
-              class='profile-picture-medium profile-picture-margin'
-              alt='{{activity.author.fullName}}'
-              height='60px'
-              style='display: inline;'
-            />
-          {{/if}}
-        </div>
+        {{#if (or (can 'show group') (can 'show user'))}}
+          <div class='hidden-xs-down'>
+            {{#if activity.group}}
+              <img
+                src='{{activity.group.avatarThumbUrlOrDefault}}'
+                class='profile-picture-medium profile-picture-margin'
+                alt='{{activity.group.fullName}}'
+                height='60px'
+                style='display: inline;'
+              />
+            {{else}}
+              <img
+                src='{{activity.author.avatarThumbUrlOrDefault}}'
+                class='profile-picture-medium profile-picture-margin'
+                alt='{{activity.author.fullName}}'
+                height='60px'
+                style='display: inline;'
+              />
+            {{/if}}
+          </div>
+        {{/if}}
 
         <div class='card-titles'>
           <h2 class='card-title' data-test-activity-title>

--- a/app/routes/activities/activity.js
+++ b/app/routes/activities/activity.js
@@ -1,6 +1,6 @@
-import { AuthenticatedRoute } from 'amber-ui/routes/application/application';
+import { ApplicationRoute } from 'amber-ui/routes/application/application';
 
-export default class ActivityRoute extends AuthenticatedRoute {
+export default class ActivityRoute extends ApplicationRoute {
   queryParams = {};
 
   get breadcrumb() {

--- a/app/routes/activities/activity/index.js
+++ b/app/routes/activities/activity/index.js
@@ -1,11 +1,8 @@
-import { AuthenticatedRoute } from 'amber-ui/routes/application/application';
+import { ApplicationRoute } from 'amber-ui/routes/application/application';
 import FormLoadOrCreateUtil from 'amber-ui/utils/form-load-or-create';
 import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
 
-export default class ActivityIndexRoute extends AuthenticatedRoute {
-  @service store;
-
+export default class ActivityIndexRoute extends ApplicationRoute {
   constructor() {
     super(...arguments);
     this.formLoadOrCreateUtil = new FormLoadOrCreateUtil(this);
@@ -47,10 +44,6 @@ export default class ActivityIndexRoute extends AuthenticatedRoute {
         // canAccess: true
       },
     ];
-  }
-
-  canAccess() {
-    return this.abilities.can('show activities');
   }
 
   model() {

--- a/app/routes/activities/index.js
+++ b/app/routes/activities/index.js
@@ -1,6 +1,6 @@
-import { AuthenticatedRoute } from 'amber-ui/routes/application/application';
+import { ApplicationRoute } from 'amber-ui/routes/application/application';
 
-export default class ActivitiesIndexRoute extends AuthenticatedRoute {
+export default class ActivitiesIndexRoute extends ApplicationRoute {
   queryParams = {
     search: {
       refreshModel: true,
@@ -31,10 +31,6 @@ export default class ActivitiesIndexRoute extends AuthenticatedRoute {
         canAccess: this.abilities.can('show ical activities'),
       },
     ];
-  }
-
-  canAccess() {
-    return this.abilities.can('show activities');
   }
 
   model(params) {


### PR DESCRIPTION
This PR enables unauthenticated viewing the activity page of activities that are marked as externally visible. It seems that this may not have been possible for a while now, even though it is a central use case for one of our committees.