### PR TITLE
album tag counter

### DIFF
--- a/app/components/cards/photo-album-card.hbs
+++ b/app/components/cards/photo-album-card.hbs
@@ -12,10 +12,10 @@
         <h3 class='card-subtitle'>{{moment-format album.date 'DD-MM-YYYY'}}</h3>
       </div>
       {{#if album.amountOfTags}}
-          <span class='album-tag-counter badge bg-info bottom-0 end-0'>
-            <FaIcon @icon='tag' />
-            {{album.amountOfTaggedPhotos}}/{{album.amountOfPhotos}}
-          </span>
+        <span class='album-tag-counter badge bg-info bottom-0 end-0'>
+          <FaIcon @icon='tag' />
+          {{album.amountOfTaggedPhotos}}/{{album.amountOfPhotos}}
+        </span>
       {{/if}}
     </div>
   </div>

--- a/app/components/cards/photo-album-card.hbs
+++ b/app/components/cards/photo-album-card.hbs
@@ -5,11 +5,18 @@
       src='{{album.albumMediumUrl}}'
       class='card-img-rounded'
     />
+    
     <div class='card-title-bar gradient-overlay-rounded'>
       <div class='card-titles'>
         <h2 class='card-title'>{{album.title}}</h2>
         <h3 class='card-subtitle'>{{moment-format album.date 'DD-MM-YYYY'}}</h3>
       </div>
+      {{#if album.amountOfTags}}
+          <span class='album-tag-counter badge bg-info bottom-0 end-0'>
+            <FaIcon @icon='tag' />
+            {{album.amountOfTags}}
+          </span>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/components/cards/photo-album-card.hbs
+++ b/app/components/cards/photo-album-card.hbs
@@ -14,7 +14,7 @@
       {{#if album.amountOfTags}}
           <span class='album-tag-counter badge bg-info bottom-0 end-0'>
             <FaIcon @icon='tag' />
-            {{album.amountOfTags}}
+            {{album.amountOfTags}}, {{album.amountOfTaggedPhotos}}/{{album.amountOfPhotos}}
           </span>
       {{/if}}
     </div>

--- a/app/components/cards/photo-album-card.hbs
+++ b/app/components/cards/photo-album-card.hbs
@@ -14,7 +14,7 @@
       {{#if album.amountOfTags}}
           <span class='album-tag-counter badge bg-info bottom-0 end-0'>
             <FaIcon @icon='tag' />
-            {{album.amountOfTags}}, {{album.amountOfTaggedPhotos}}/{{album.amountOfPhotos}}
+            {{album.amountOfTaggedPhotos}}/{{album.amountOfPhotos}}
           </span>
       {{/if}}
     </div>

--- a/app/components/cards/photo-album-card.hbs
+++ b/app/components/cards/photo-album-card.hbs
@@ -11,7 +11,7 @@
         <h2 class='card-title'>{{album.title}}</h2>
         <h3 class='card-subtitle'>{{moment-format album.date 'DD-MM-YYYY'}}</h3>
       </div>
-      {{#if album.amountOfTags}}
+      {{#if album.amountOfTaggedPhotos}}
         <span class='album-tag-counter badge bg-info bottom-0 end-0'>
           <FaIcon @icon='tag' />
           {{album.amountOfTaggedPhotos}}/{{album.amountOfPhotos}}

--- a/app/models/photo-album.js
+++ b/app/models/photo-album.js
@@ -35,18 +35,10 @@ export default class PhotoAlbum extends Model {
     return this.photos?.sortBy('exifDateTimeOriginal', 'createdAt');
   }
 
-  get amountOfTags() {
+  get amountOfTaggedPhotos() {
     var counter = 0;
     for (var photo of this.photos._objects) {
-      counter += photo.amountOfTags;
-    }
-    return counter;
-  }
-
-  get amountOfTaggedPhotos() { //not used anymore
-    var counter = 0;
-    for (var photo of this.photos._objects) {
-      counter += photo.amountOfTags>0? 1 : 0;
+      counter += photo.amountOfTags > 0 ? 1 : 0;
     }
     return counter;
   }

--- a/app/models/photo-album.js
+++ b/app/models/photo-album.js
@@ -37,9 +37,9 @@ export default class PhotoAlbum extends Model {
 
   get amountOfTaggedPhotos() {
     var counter = 0;
-    for (var photo of this.photos._objects) {
+    this.photos.content.forEach((photo) => {
       counter += photo.amountOfTags > 0 ? 1 : 0;
-    }
+    })
     return counter;
   }
 

--- a/app/models/photo-album.js
+++ b/app/models/photo-album.js
@@ -36,14 +36,21 @@ export default class PhotoAlbum extends Model {
   }
 
   get amountOfTags() {
-    var c = 0
-    for(var p of this.photos._objects){
-      c += p.amountOfTags
-      console.log(c)
+    var counter = 0
+    for(var photo of this.photos._objects){
+      counter += photo.amountOfTags
     } 
-    
-    //console.log(this.photos?._objects[1]?.amountOfTags)
-    return c
+    return counter
+  }
+  get amountOfTaggedPhotos() {
+    var counter = 0
+    for(var photo of this.photos._objects){
+      counter += photo.amountOfTags>0? 1 : 0
+    } 
+    return counter
+  }
+  get amountOfPhotos() {
+    return this.photos.length
   }
 
   // Methods

--- a/app/models/photo-album.js
+++ b/app/models/photo-album.js
@@ -35,6 +35,17 @@ export default class PhotoAlbum extends Model {
     return this.photos?.sortBy('exifDateTimeOriginal', 'createdAt');
   }
 
+  get amountOfTags() {
+    var c = 0
+    for(var p of this.photos._objects){
+      c += p.amountOfTags
+      console.log(c)
+    } 
+    
+    //console.log(this.photos?._objects[1]?.amountOfTags)
+    return c
+  }
+
   // Methods
   isOwner(user) {
     if (user.get('id') === this.author.get('id')) {

--- a/app/models/photo-album.js
+++ b/app/models/photo-album.js
@@ -39,7 +39,7 @@ export default class PhotoAlbum extends Model {
     var counter = 0;
     this.photos.content.forEach((photo) => {
       counter += photo.amountOfTags > 0 ? 1 : 0;
-    })
+    });
     return counter;
   }
 

--- a/app/models/photo-album.js
+++ b/app/models/photo-album.js
@@ -36,21 +36,23 @@ export default class PhotoAlbum extends Model {
   }
 
   get amountOfTags() {
-    var counter = 0
-    for(var photo of this.photos._objects){
-      counter += photo.amountOfTags
-    } 
-    return counter
+    var counter = 0;
+    for (var photo of this.photos._objects) {
+      counter += photo.amountOfTags;
+    }
+    return counter;
   }
-  get amountOfTaggedPhotos() {
-    var counter = 0
-    for(var photo of this.photos._objects){
-      counter += photo.amountOfTags>0? 1 : 0
-    } 
-    return counter
+
+  get amountOfTaggedPhotos() { //not used anymore
+    var counter = 0;
+    for (var photo of this.photos._objects) {
+      counter += photo.amountOfTags>0? 1 : 0;
+    }
+    return counter;
   }
+
   get amountOfPhotos() {
-    return this.photos.length
+    return this.photos.length;
   }
 
   // Methods

--- a/app/styles/components/cards/photo-album-card.scss
+++ b/app/styles/components/cards/photo-album-card.scss
@@ -23,8 +23,8 @@
   .album-tag-counter {
     position: absolute;
     bottom: 0;
-    margin-bottom: 1rem;
     margin-right: 15px;
+    margin-bottom: 1rem;
     padding-left: 5px;
   }
 }

--- a/app/styles/components/cards/photo-album-card.scss
+++ b/app/styles/components/cards/photo-album-card.scss
@@ -19,4 +19,12 @@
   .card-title {
     font-size: 1.5rem;
   }
+
+  .album-tag-counter {
+    position: absolute;
+    bottom: 0;
+    margin-bottom: 1rem;
+    margin-right: 15px;
+    padding-left: 5px;
+  }
 }

--- a/app/styles/routes/photos.scss
+++ b/app/styles/routes/photos.scss
@@ -8,6 +8,7 @@
     bottom: 0;
     margin-bottom: 1rem;
     margin-left: 15px;
+    margin-right: 15px;
     padding-left: 5px;
   }
 

--- a/app/styles/routes/photos.scss
+++ b/app/styles/routes/photos.scss
@@ -8,7 +8,6 @@
     bottom: 0;
     margin-bottom: 1rem;
     margin-left: 15px;
-    margin-right: 15px;
     padding-left: 5px;
   }
 

--- a/app/templates/photo-albums/photo-album/photos/index.hbs
+++ b/app/templates/photo-albums/photo-album/photos/index.hbs
@@ -21,10 +21,16 @@
         @route='photo-albums.photo-album.photos.photo'
         @model={{photo.id}}
       >
-        {{#if photo.amountOfComments}}
+        {{#if (or photo.amountOfComments photo.amountOfTags)}}
           <span class='comments-counter badge bg-info bottom-0 start-0'>
-            <FaIcon @icon='comments' />
-            {{photo.amountOfComments}}
+            {{#if photo.amountOfComments}}
+              <FaIcon @icon='comments' />
+              {{photo.amountOfComments}}
+            {{/if}}
+            {{#if photo.amountOfTags}}
+              <FaIcon @icon='tag' />
+              {{photo.amountOfTags}}
+            {{/if}}
           </span>
         {{/if}}
         <img class='image' src='{{photo.imageThumbUrl}}' />

--- a/tests/unit/models/photo-album-test.js
+++ b/tests/unit/models/photo-album-test.js
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -23,7 +22,7 @@ module('Unit | Model | photo-album', function (hooks) {
     photos[0].amountOfTags = 0;
     photos[1].amountOfTags = 1;
     photos[2].amountOfTags = 5;
-    assert.equal(album.amountOfPhotos, 3, "Amount of photos is correct");
-    assert.equal(album.amountOfTaggedPhotos, 2, "Amount of tags in album is correct");
+    assert.equal(album.amountOfPhotos, 3, 'Amount of photos is correct');
+    assert.equal(album.amountOfTaggedPhotos, 2, 'Amount of tagged photos in album is correct');
   });
 });

--- a/tests/unit/models/photo-album-test.js
+++ b/tests/unit/models/photo-album-test.js
@@ -1,0 +1,29 @@
+import { run } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+let album;
+let photos = [];
+
+module('Unit | Model | photo-album', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    const store = this.owner.lookup('service:store');
+    photos = [
+      store.createRecord('Photo'),
+      store.createRecord('Photo'),
+      store.createRecord('Photo'),
+    ];
+    album = store.createRecord('PhotoAlbum', { photos });
+  });
+
+  test('Photo count', function (assert) {
+    assert.expect(2);
+    photos[0].amountOfTags = 0;
+    photos[1].amountOfTags = 1;
+    photos[2].amountOfTags = 5;
+    assert.equal(album.amountOfPhotos, 3, "Amount of photos is correct");
+    assert.equal(album.amountOfTaggedPhotos, 2, "Amount of tags in album is correct");
+  });
+});

--- a/tests/unit/models/photo-album-test.js
+++ b/tests/unit/models/photo-album-test.js
@@ -23,6 +23,10 @@ module('Unit | Model | photo-album', function (hooks) {
     photos[1].amountOfTags = 1;
     photos[2].amountOfTags = 5;
     assert.equal(album.amountOfPhotos, 3, 'Amount of photos is correct');
-    assert.equal(album.amountOfTaggedPhotos, 2, 'Amount of tagged photos in album is correct');
+    assert.equal(
+      album.amountOfTaggedPhotos,
+      2,
+      'Amount of tagged photos in album is correct'
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8827,24 +8827,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001313":
-  version: 1.0.30001458
-  resolution: "caniuse-lite@npm:1.0.30001458"
-  checksum: 258cc5a25babbbfe483bf788c6f321a19400ff80b2bf156b360bac09a6f9f4da44516350d187a30395667cb142c682d9ea96577ea0df236d35f76234b07ccb41
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001449":
-  version: 1.0.30001485
-  resolution: "caniuse-lite@npm:1.0.30001485"
-  checksum: 2db8a9e5facf8df5275c96e44714a6caf3b9485813be1fe0aa5a72a7ced974137adeeed806a9a97f713d2f6d1b5c342949b88355ee0323ba35656bfa00d57fea
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001541":
-  version: 1.0.30001547
-  resolution: "caniuse-lite@npm:1.0.30001547"
-  checksum: ec0fc2b46721887f6f4aca1f3902f03d9a1a07416d16a86b7cd4bfba60e7b6b03ab3969659d3ea0158cc2f298972c80215c06c9457eb15c649d7780e8f5e91a7
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001313, caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001541":
+  version: 1.0.30001668
+  resolution: "caniuse-lite@npm:1.0.30001668"
+  checksum: ce6996901b5883454a8ddb3040f82342277b6a6275876dfefcdecb11f7e472e29877f34cae47c2b674f08f2e71971dd4a2acb9bc01adfe8421b7148a7e9e8297
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
(Issue#870) A small tag is added to the photo album cover cards, the number of photos that have been tagged out of the total amount of photos.

![image](https://github.com/user-attachments/assets/4b6cf672-42aa-47d0-9854-f016ff9a4b03)

The tag does not show up for albums in which none of the photos have been tagged or that do not contain any photos.

The goal is to provide an easy way to check if the photos in the album have been tagged.

(Issue#863) The similar issue is fixed by also displaying the tag count of each photo in the same  box as the comment count.

![image](https://github.com/user-attachments/assets/3daf2c5a-006d-40b2-baaf-18dbfdf25532)
