### PR TITLE
Remove IBAN option from group export

### DIFF
--- a/app/controllers/groups/group/export.js
+++ b/app/controllers/groups/group/export.js
@@ -72,16 +72,12 @@ export default class GroupExportController extends Controller {
       label: 'Stad',
     },
     {
-      value: 'foodPreferences',
+      value: 'food_preferences',
       label: 'Dieetwensen',
     },
     {
       value: 'vegetarian',
       label: 'Vegetariër',
-    },
-    {
-      value: 'food_preferences',
-      label: 'Dieetwensen',
     },
     {
       value: 'phone_number',

--- a/app/controllers/groups/group/export.js
+++ b/app/controllers/groups/group/export.js
@@ -80,6 +80,10 @@ export default class GroupExportController extends Controller {
       label: 'Vegetariër',
     },
     {
+      value: 'food_preferences',
+      label: 'Dieetwensen',
+    },
+    {
       value: 'phone_number',
       label: 'Telefoonnummer',
     },
@@ -108,24 +112,12 @@ export default class GroupExportController extends Controller {
       label: 'IFES voorkeur',
     },
     {
-      value: 'iban',
-      label: 'IBAN',
-    },
-    {
-      value: 'iban_holder',
-      label: 'IBAN tenaamgestelde',
-    },
-    {
       value: 'emergency_contact',
       label: 'Noodcontact',
     },
     {
       value: 'emergency_number',
       label: 'Noodnummer',
-    },
-    {
-      value: 'avatar_url',
-      label: 'Profielfoto url',
     },
   ];
 


### PR DESCRIPTION
Fixes https://github.com/csvalpha/amber-ui/issues/940

I removed the ability to download all IBAN because it is not stored in the user table but in the mandates table. besides that it is really sensitive data.

If we need this functionality we need to a export button to the mandates tab or fix it some other way
