### PR TITLE
Remove ability to view a photo when not logged in

### DIFF
--- a/app/templates/photo-albums/photo-album/photos/index.hbs
+++ b/app/templates/photo-albums/photo-album/photos/index.hbs
@@ -18,26 +18,32 @@
 
 <div class='row'>
   {{#each sortedPhotos as |photo|}}
-    <div class='col-md-3 col-xs-6 photo-album-image-card'>
-      <LinkTo
-        @route='photo-albums.photo-album.photos.photo'
-        @model={{photo.id}}
-      >
-        {{#if (or (and photo.amountOfComments (can 'show photo-comment')) (and photo.amountOfTags (can 'show photo-tag')))}}
-          <span class='comments-counter badge bg-info bottom-0 start-0'>
-            {{#if (and photo.amountOfComments (can 'show photo-comment'))}}
-              <FaIcon @icon='comments' />
-              {{photo.amountOfComments}}
-            {{/if}}
-            {{#if (and photo.amountOfTags (can 'show photo-tag'))}}
-              <FaIcon @icon='tag' />
-              {{photo.amountOfTags}}
-            {{/if}}
-          </span>
-        {{/if}}
+    {{#if this.session.isAuthenticated}}
+      <div class='col-md-3 col-xs-6 photo-album-image-card'>
+        <LinkTo
+          @route='photo-albums.photo-album.photos.photo'
+          @model={{photo.id}}
+        >
+          {{#if (or (and photo.amountOfComments (can 'show photo-comment')) (and photo.amountOfTags (can 'show photo-tag')))}}
+            <span class='comments-counter badge bg-info bottom-0 start-0'>
+              {{#if (and photo.amountOfComments (can 'show photo-comment'))}}
+                <FaIcon @icon='comments' />
+                {{photo.amountOfComments}}
+              {{/if}}
+              {{#if (and photo.amountOfTags (can 'show photo-tag'))}}
+                <FaIcon @icon='tag' />
+                {{photo.amountOfTags}}
+              {{/if}}
+            </span>
+          {{/if}}
+          <img class='image' src='{{photo.imageThumbUrl}}' />
+        </LinkTo>
+      </div>
+    {{else}}
+      <div class='col-md-3 col-xs-6 photo-album-image-card'>
         <img class='image' src='{{photo.imageThumbUrl}}' />
-      </LinkTo>
-    </div>
+      </div>
+    {{/if}}
   {{else}}
     <div class='alert alert-warning'>
       <LinkTo @route='photo-albums.photo-album.edit' @model={{model.id}}>


### PR DESCRIPTION
Solves https://github.com/csvalpha/amber-ui/issues/978

This is being removed because it looked really ugly and there is no need for a public person to view all photos one by one