### PR TITLE
Add CORS for authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-eslint": "^10.1.0",
     "bootstrap": "^5.2.3",
     "broccoli-asset-rev": "^3.0.0",
+    "cors": "^2.8.5",
     "ember-async-data": "^0.7.0",
     "ember-auto-import": "^2.2.4",
     "ember-bootstrap": "^5.1.1",

--- a/server/index.js
+++ b/server/index.js
@@ -10,11 +10,14 @@
 // };
 
 module.exports = function (app) {
+  const cors = require('cors');
   const globSync = require('glob').sync;
   const mocks = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
   const proxies = globSync('./proxies/**/*.js', { cwd: __dirname }).map(
     require
   );
+
+  app.use(cors({ origin: 'http://localhost:5000' }));
 
   // Log proxy requests
   const morgan = require('morgan');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5537,6 +5537,7 @@ __metadata:
     babel-eslint: ^10.1.0
     bootstrap: ^5.2.3
     broccoli-asset-rev: ^3.0.0
+    cors: ^2.8.5
     ember-async-data: ^0.7.0
     ember-auto-import: ^2.2.4
     ember-bootstrap: ^5.1.1
@@ -9684,7 +9685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cors@npm:~2.8.5":
+"cors@npm:^2.8.5, cors@npm:~2.8.5":
   version: 2.8.5
   resolution: "cors@npm:2.8.5"
   dependencies:


### PR DESCRIPTION
We need CORS on amber-ui for proper authentication with Sofia.
This was not needed in the past because we did not use a proper AJAX request
https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added cross-origin request (CORS) support to enable communication from localhost:5000 to the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->