### PR TITLE
Fix sidebar color 

### DIFF
--- a/app/styles/components/menu-sidebar.scss
+++ b/app/styles/components/menu-sidebar.scss
@@ -69,7 +69,7 @@ $profile-menu-height: 360px;
     }
   }
 
-  .sidebar-item-minor {
+  .menu-sidebar-item.sidebar-item-minor {
     color: $gray-600;
 
     &:hover {


### PR DESCRIPTION
This bug happend due to the css not being specific enough
Fixes https://github.com/csvalpha/amber-ui/issues/1060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved CSS selector specificity for sidebar menu items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->